### PR TITLE
chore: bump CI actions to latest majors and go directive to 1.26.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v7
         with:
           go-version: "1.26"
           cache: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,7 +35,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push
         uses: docker/build-push-action@v7

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tphakala/autotask-mcp
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/modelcontextprotocol/go-sdk v1.6.1


### PR DESCRIPTION
Basic maintenance pass.

## GitHub Actions
Two major bumps that fell outside Dependabot's minor/patch `github-actions` group, so they were never rolled into the grouped PRs and instead sat as individual open PRs since July 8:

- `actions/setup-go` v5 to **v7** (Dependabot PR #20 only reached v6; going straight to latest skips the extra 6-to-7 round-trip)
- `docker/setup-buildx-action` v3 to **v4** (supersedes Dependabot PR #21)

Both open Dependabot PRs auto-close once main is at or above their target. Every other action (checkout, codeql, login, metadata, build-push) is already on its current major.

## Go toolchain
Bump the `go.mod` directive `1.26.1` to `1.26.5` so the build minimum enforces the GO-2026-5856 toolchain fix. `govulncheck` was already clean under the installed 1.26.5, so this is hygiene rather than a live fix.

## Go modules
Direct deps (`go-autotask` v1.4.4, `go-sdk` v1.6.1) are current on stable. Indirect updates are left to Dependabot's weekly sweep.

## Verification
`go build`, `go vet`, and `go test -race -cover ./...` all pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain configuration to version 1.26.5.
  * Updated build and publishing workflows to use newer tooling versions.
  * Existing build, test, and Docker publishing behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->