### PR TITLE
chore: update deps and guard TDQS parameter semantics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
-	golang.org/x/tools v0.47.0 // indirect
+	golang.org/x/tools v0.48.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -16,9 +16,9 @@ github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zI
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
-golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
-golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
-golang.org/x/tools v0.47.0 h1:7Kn5x/d1svx/PzryTsqeoZN4TZwqeH5pGWjefhLi/1Q=
-golang.org/x/tools v0.47.0/go.mod h1:dFHnyTvFWY212G+h7ZY4Vsp/K3U4/7W9TyVaAul8uCA=
+golang.org/x/tools v0.48.0 h1:3+hClM1aLL5mjMKm5ovokw9epgRXPuu2tILgismM6RE=
+golang.org/x/tools v0.48.0/go.mod h1:08xX0orndb/F7jJxGDicx061tyd5pcMto75YMAXr6lk=

--- a/tdqs_test.go
+++ b/tdqs_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -11,9 +12,10 @@ import (
 // TestTDQS_ToolDefinitionsQuality asserts, across every registered tool, the
 // invariants that keep the server's Tool Definition Quality Score in tier A:
 // a substantive description, annotations carrying a title, a trailing
-// read/write marker consistent with the readOnly hint, and no em or en dashes.
-// It exercises the real tools/list path over the in-memory transport, so it
-// also confirms annotations serialize end to end.
+// read/write marker consistent with the readOnly hint, every input parameter
+// carrying a schema description, and no em or en dashes. It exercises the real
+// tools/list path over the in-memory transport, so it also confirms
+// annotations and the input schema serialize end to end.
 func TestTDQS_ToolDefinitionsQuality(t *testing.T) {
 	ctx := context.Background()
 	_, client := autotasktest.NewServer(t)
@@ -46,6 +48,27 @@ func TestTDQS_ToolDefinitionsQuality(t *testing.T) {
 		for _, s := range []string{tool.Description, tool.Annotations.Title} {
 			if strings.ContainsRune(s, emDash) || strings.ContainsRune(s, enDash) {
 				t.Errorf("%s: contains em/en dash: %q", name, s)
+			}
+		}
+
+		// Parameter Semantics (TDQS): every declared input parameter must carry a
+		// description, so the schema conveys meaning beyond the bare field name.
+		// InputSchema arrives as decoded JSON over the tools/list path, so parse
+		// it generically rather than depending on the server-side struct type.
+		var schema struct {
+			Properties map[string]struct {
+				Description string `json:"description"`
+			} `json:"properties"`
+		}
+		if raw, err := json.Marshal(tool.InputSchema); err != nil {
+			t.Errorf("%s: cannot marshal input schema: %v", name, err)
+		} else if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Errorf("%s: cannot parse input schema: %v", name, err)
+		} else {
+			for pname, p := range schema.Properties {
+				if strings.TrimSpace(p.Description) == "" {
+					t.Errorf("%s: parameter %q lacks a schema description", name, pname)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Summary

Dependency maintenance plus a TDQS review of the tool definitions.

**Dependencies:** ran `go get -u ./...` and `go mod tidy`. Only two in-graph indirect modules had newer compatible releases: `golang.org/x/sys` 0.46.0 to 0.47.0 and `golang.org/x/tools` 0.47.0 to 0.48.0. The direct dependencies (`go-sdk` v1.6.1, `go-autotask` v1.4.4) are already at their latest tags. The other modules that `go list -u -m all` reports as outdated (goldmark, x/net, x/sync, x/mod, x/telemetry, cloud.google metadata) are test dependencies of dependencies that sit outside this module's build graph, so `tidy` correctly leaves them out and they cannot be bumped here without adding spurious requires.

**TDQS review:** I reviewed the ~59 tool definitions against the [Glama Tool Definition Quality Score](https://github.com/glama-ai/tool-definition-quality-score) spec. They already sit in tier A across all six dimensions: specific verb+resource purpose that distinguishes each tool from its siblings, explicit when/when-not usage guidance with named alternatives, `Read-only.`/`Writes to Autotask.` markers that match the `readOnlyHint` annotation (so no annotation contradictions), and per-parameter `jsonschema` descriptions. No tool definitions needed changing.

The one tier-A checklist item not present anywhere is an MCP `outputSchema`. Adding it properly would mean refactoring all ~59 handlers to return schema-validated structured content instead of their current text/JSON results, which is a large, risky change well beyond a maintenance pass, so it is intentionally out of scope here.

**Test hardening:** the enforcing `TestTDQS_ToolDefinitionsQuality` guarded description length, annotations, and the read/write marker, but not the Parameter Semantics dimension. This PR adds a check over the real `tools/list` path that every input-schema property carries a non-empty description, locking that dimension against future drift. Verified it has teeth (search_tickets reports 10 properties, create_ticket 8, no-arg tools 0), and it currently passes because every tool already complies.

## Verification

- `go build ./...` clean
- `go vet ./...` clean
- `go test -race ./...` passes
- `TestTDQS_ToolDefinitionsQuality` passes with the new parameter guard

## Note (not addressed here)

Several pre-existing files are not `gofmt`-clean (import ordering and one struct-field alignment). CI runs build, vet, and `go test -race -cover` but no format lint, so this never surfaced. It is unrelated to this change and left alone to avoid churn; happy to open a separate PR that runs `gofmt -w` and adds a format check to CI if you want it.
