### PR TITLE
feat(tools): adopt typed StructuredContent outputs and expand wire-protocol test suite

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -150,6 +150,24 @@ func TestIntegration_CreateAndGetTicket(t *testing.T) {
 	if getResult.IsError {
 		t.Fatalf("get_ticket_details returned error: %v", getResult.Content)
 	}
+	if len(getResult.Content) == 0 {
+		t.Fatal("expected non-empty content in get_ticket_details response")
+	}
+	getText, ok := getResult.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent in get_ticket_details response")
+	}
+	var getResp map[string]any
+	if err := json.Unmarshal([]byte(getText.Text), &getResp); err != nil {
+		t.Fatalf("failed to parse get_ticket_details response: %v", err)
+	}
+	idVal, ok := getResp["id"]
+	if !ok {
+		t.Fatal("expected 'id' in get_ticket_details response")
+	}
+	if fVal, isFloat := idVal.(float64); !isFloat || int64(fVal) != ticketID {
+		t.Errorf("expected id=%d, got %v", ticketID, idVal)
+	}
 }
 
 // TestIntegration_SearchCompanies verifies the search_companies tool returns
@@ -179,6 +197,13 @@ func TestIntegration_SearchCompanies(t *testing.T) {
 	}
 	if len(result.Content) == 0 {
 		t.Fatal("expected at least one content item")
+	}
+	textContent, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatal("expected TextContent in search_companies response")
+	}
+	if !strings.Contains(textContent.Text, "Alpha Corp") || !strings.Contains(textContent.Text, "Beta LLC") {
+		t.Errorf("expected search_companies to contain seeded companies, got: %s", textContent.Text)
 	}
 }
 

--- a/services/formatter.go
+++ b/services/formatter.go
@@ -18,19 +18,6 @@ var SummaryFields = map[string][]string{
 	"timeEntries":               {"id", "resourceID", "ticketID", "projectID", "taskID", "dateWorked", "hoursWorked", "summaryNotes"},
 }
 
-// CompactSearchTools is the set of tool names that use compact formatting.
-var CompactSearchTools = map[string]bool{
-	"autotask_search_tickets":                    true,
-	"autotask_search_companies":                  true,
-	"autotask_search_contacts":                   true,
-	"autotask_search_projects":                   true,
-	"autotask_search_tasks":                      true,
-	"autotask_search_resources":                  true,
-	"autotask_search_billing_items":              true,
-	"autotask_search_billing_item_approval_levels": true,
-	"autotask_search_time_entries":               true,
-}
-
 // FormatOptions controls result limits for compact responses.
 type FormatOptions struct {
 	MaxResults int
@@ -38,16 +25,24 @@ type FormatOptions struct {
 
 // CompactSummary holds bounded search metadata returned with a compact response.
 type CompactSummary struct {
-	Returned   int    `json:"returned"`
-	HasMore    bool   `json:"hasMore"`
-	MaxResults int    `json:"maxResults,omitempty"`
-	Hint       string `json:"hint,omitempty"`
+	Returned   int    `json:"returned" jsonschema:"Number of items returned in this response"`
+	HasMore    bool   `json:"hasMore" jsonschema:"Whether more items match the search criteria"`
+	MaxResults int    `json:"maxResults,omitempty" jsonschema:"Effective max results limit used"`
+	Hint       string `json:"hint,omitempty" jsonschema:"Guidance when results are capped"`
 }
 
 // CompactResponse is the complete compact-formatted search result.
 type CompactResponse struct {
-	Summary CompactSummary   `json:"summary"`
-	Items   []map[string]any `json:"items"`
+	Summary CompactSummary   `json:"summary" jsonschema:"Search metadata summary"`
+	Items   []map[string]any `json:"items" jsonschema:"Matching entity records with framed untrusted fields"`
+}
+
+// untrustedFields lists the known external user-supplied fields that must be framed.
+var untrustedFields = []string{
+	"description", "title", "note", "summaryNotes", "details",
+	"problemDescription", "resolution", "internalNotes", "cause", "name",
+	"projectName", "companyName", "referenceTitle", "referenceName",
+	"fileName", "serviceName", "serviceBundleName",
 }
 
 // FrameUntrustedContent wraps external user-supplied text with untrusted data boundary markers,
@@ -70,12 +65,6 @@ func FrameUntrustedContent(content string) string {
 func FrameUntrustedMapFields(m map[string]any) {
 	if m == nil {
 		return
-	}
-	untrustedFields := []string{
-		"description", "title", "note", "summaryNotes", "details",
-		"problemDescription", "resolution", "internalNotes", "cause", "name",
-		"projectName", "companyName", "referenceTitle", "referenceName",
-		"fileName", "serviceName", "serviceBundleName",
 	}
 	for _, field := range untrustedFields {
 		if val, ok := m[field].(string); ok && val != "" {
@@ -172,6 +161,9 @@ func pickSummaryFields(item map[string]any, entityType string) map[string]any {
 		}
 		if v, ok := enhanced["resourceName"]; ok {
 			result["resourceName"] = v
+		}
+		if v, ok := enhanced["projectLeadResourceName"]; ok {
+			result["projectLead"] = v
 		}
 	}
 

--- a/tools/attachments.go
+++ b/tools/attachments.go
@@ -2,7 +2,7 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -38,16 +38,16 @@ func RegisterAttachmentTools(s *mcp.Server, client *autotask.Client) {
 }
 
 // getTicketAttachmentHandler returns a handler that retrieves a single ticket attachment.
-func getTicketAttachmentHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketAttachmentInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketAttachmentInput) (*mcp.CallToolResult, any, error) {
+func getTicketAttachmentHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketAttachmentInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketAttachmentInput) (*mcp.CallToolResult, map[string]any, error) {
 		attachment, err := autotask.Get[entities.TicketAttachment](ctx, client, in.AttachmentID)
 		if err != nil {
-			return errorResult("failed to get ticket attachment %d: %v", in.AttachmentID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(attachment)
 		if err != nil {
-			return errorResult("failed to convert ticket attachment: %v", err)
+			return nil, nil, err
 		}
 
 		delete(m, "fullPath")
@@ -55,28 +55,28 @@ func getTicketAttachmentHandler(client *autotask.Client) func(ctx context.Contex
 			delete(m, "data")
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket attachment: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchTicketAttachmentsHandler returns a handler that lists attachments for a ticket without heavy base64 data.
-func searchTicketAttachmentsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketAttachmentsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketAttachmentsInput) (*mcp.CallToolResult, any, error) {
+func searchTicketAttachmentsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketAttachmentsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketAttachmentsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		attachments, err := autotask.ListChildRaw(ctx, client, "Tickets", in.TicketID, "TicketAttachments")
 		if err != nil {
-			return errorResult("failed to list ticket attachments for ticket %d: %v", in.TicketID, err)
+			var notFound *autotask.NotFoundError
+			if errors.As(err, &notFound) {
+				return emptySearchResult()
+			}
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(attachments) == 0 {
-			return textResult("No ticket attachments found")
+			return emptySearchResult()
 		}
 
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
+		hasMore := len(attachments) >= maxResults && maxResults > 0
 		if len(attachments) > maxResults {
 			attachments = attachments[:maxResults]
 		}
@@ -87,11 +87,19 @@ func searchTicketAttachmentsHandler(client *autotask.Client) func(ctx context.Co
 			services.FrameUntrustedMapFields(attachment)
 		}
 
-		data, err := json.MarshalIndent(attachments, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket attachments: %v", err)
+		hint := ""
+		if hasMore {
+			hint = "Maximum result limit reached. Use narrower search filters to find specific records."
 		}
 
-		return textResult("%s", string(data))
+		return nil, services.CompactResponse{
+			Summary: services.CompactSummary{
+				Returned:   len(attachments),
+				HasMore:    hasMore,
+				MaxResults: maxResults,
+				Hint:       hint,
+			},
+			Items: attachments,
+		}, nil
 	}
 }

--- a/tools/attachments_test.go
+++ b/tools/attachments_test.go
@@ -2,10 +2,10 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/go-autotask/entities"
@@ -18,42 +18,87 @@ func TestRegisterAttachmentTools_NoPanic(t *testing.T) {
 	RegisterAttachmentTools(s, client)
 }
 
-// TestGetTicketAttachmentHandler_NotFound tests that a missing attachment returns an error result.
+// TestGetTicketAttachmentHandler_NotFound tests that a missing attachment returns an error result over wire.
 func TestGetTicketAttachmentHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getTicketAttachmentHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketAttachmentInput{AttachmentID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_attachment",
+		Arguments: map[string]any{
+			"attachmentId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing attachment")
 	}
 }
 
-// TestSearchTicketAttachmentsHandler_NoPanic verifies the search handler does not panic.
-func TestSearchTicketAttachmentsHandler_NoPanic(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchTicketAttachmentsHandler(client)
+// TestSearchTicketAttachmentsHandler_NoResults verifies empty search response over wire.
+func TestSearchTicketAttachmentsHandler_NoResults(t *testing.T) {
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTicketAttachmentsInput{TicketID: 3001})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_ticket_attachments",
+		Arguments: map[string]any{
+			"ticketId": 3001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
 	}
-	// Note: IsError may be true when mock server has no ticket store for the parent ID.
-	// The key assertion is that the handler doesn't panic and returns a valid result.
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned attachments, got %d", resp.Summary.Returned)
+	}
 }
 
-// TestGetTicketAttachmentHandler_StripDataByDefault tests that attachment data is stripped by default.
+// TestSearchTicketAttachmentsHandler_WithResults verifies seeded attachments are returned with data stripped.
+func TestSearchTicketAttachmentsHandler_WithResults(t *testing.T) {
+	att := &entities.TicketAttachment{
+		ID:       autotask.Set(int64(7001)),
+		TicketID: autotask.Set(int64(3001)),
+		Title:    autotask.Set("test attachment"),
+		Data:     autotask.Set("SGVsbG8gV29ybGQ="),
+		FullPath: autotask.Set("/path/to/test.txt"),
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(att))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_ticket_attachments",
+		Arguments: map[string]any{
+			"ticketId": 3001,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Fatalf("expected at least 1 attachment, got %d", resp.Summary.Returned)
+	}
+	if _, exists := resp.Items[0]["data"]; exists {
+		t.Errorf("expected 'data' field to be stripped from search results")
+	}
+	if _, exists := resp.Items[0]["fullPath"]; exists {
+		t.Errorf("expected 'fullPath' field to be stripped from search results")
+	}
+}
+
+// TestGetTicketAttachmentHandler_StripDataByDefault tests that attachment data is stripped by default over wire.
 func TestGetTicketAttachmentHandler_StripDataByDefault(t *testing.T) {
 	att := &entities.TicketAttachment{
 		ID:       autotask.Set(int64(7001)),
@@ -62,29 +107,24 @@ func TestGetTicketAttachmentHandler_StripDataByDefault(t *testing.T) {
 		Data:     autotask.Set("SGVsbG8gV29ybGQ="),
 		FullPath: autotask.Set("/path/to/test.txt"),
 	}
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(att))
-
-	handler := getTicketAttachmentHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(att))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketAttachmentInput{AttachmentID: 7001, IncludeData: false})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_attachment",
+		Arguments: map[string]any{
+			"attachmentId": 7001,
+			"includeData":  false,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
+	if result.IsError {
 		t.Fatalf("expected non-error result, got: %v", result)
 	}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &m); err != nil {
-		t.Fatalf("unmarshal error: %v", err)
-	}
-
+	m := parseStructuredContent[map[string]any](t, result)
 	if _, exists := m["data"]; exists {
 		t.Errorf("expected 'data' field to be stripped, but found: %v", m["data"])
 	}
@@ -93,7 +133,7 @@ func TestGetTicketAttachmentHandler_StripDataByDefault(t *testing.T) {
 	}
 }
 
-// TestGetTicketAttachmentHandler_IncludeData tests that attachment data is included when requested.
+// TestGetTicketAttachmentHandler_IncludeData tests that attachment data is included when requested over wire.
 func TestGetTicketAttachmentHandler_IncludeData(t *testing.T) {
 	att := &entities.TicketAttachment{
 		ID:       autotask.Set(int64(7001)),
@@ -102,30 +142,26 @@ func TestGetTicketAttachmentHandler_IncludeData(t *testing.T) {
 		Data:     autotask.Set("SGVsbG8gV29ybGQ="),
 		FullPath: autotask.Set("/path/to/test.txt"),
 	}
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(att))
-
-	handler := getTicketAttachmentHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(att))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketAttachmentInput{AttachmentID: 7001, IncludeData: true})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_attachment",
+		Arguments: map[string]any{
+			"attachmentId": 7001,
+			"includeData":  true,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
+	if result.IsError {
 		t.Fatalf("expected non-error result, got: %v", result)
 	}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &m); err != nil {
-		t.Fatalf("unmarshal error: %v", err)
-	}
-
+	m := parseStructuredContent[map[string]any](t, result)
 	if _, exists := m["data"]; !exists {
 		t.Errorf("expected 'data' field to be present when includeData=true")
 	}
 }
+

--- a/tools/billing.go
+++ b/tools/billing.go
@@ -2,7 +2,7 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -59,33 +59,28 @@ func RegisterBillingTools(s *mcp.Server, client *autotask.Client, mapper *servic
 }
 
 // getBillingItemHandler returns a handler that retrieves a single billing item.
-func getBillingItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetBillingItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetBillingItemInput) (*mcp.CallToolResult, any, error) {
+func getBillingItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetBillingItemInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetBillingItemInput) (*mcp.CallToolResult, map[string]any, error) {
 		if in.BillingItemID == 0 {
-			return errorResult("billingItemId is required")
+			return nil, nil, fmt.Errorf("billingItemId is required")
 		}
 		item, err := autotask.Get[entities.BillingItem](ctx, client, in.BillingItemID)
 		if err != nil {
-			return errorResult("failed to get billing item %d: %v", in.BillingItemID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(item)
 		if err != nil {
-			return errorResult("failed to convert billing item: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal billing item: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchBillingItemsHandler returns a handler that searches billing items.
-func searchBillingItemsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemsInput) (*mcp.CallToolResult, any, error) {
+func searchBillingItemsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -113,16 +108,16 @@ func searchBillingItemsHandler(client *autotask.Client, mapper *services.Mapping
 
 		items, err := autotask.List[entities.BillingItem](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search billing items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(items) == 0 {
-			return textResult("No billing items found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(items)
 		if err != nil {
-			return errorResult("failed to convert billing items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_billing_items", maxResults)
@@ -130,8 +125,8 @@ func searchBillingItemsHandler(client *autotask.Client, mapper *services.Mapping
 }
 
 // searchBillingItemApprovalLevelsHandler returns a handler that searches billing item approval levels.
-func searchBillingItemApprovalLevelsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemApprovalLevelsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemApprovalLevelsInput) (*mcp.CallToolResult, any, error) {
+func searchBillingItemApprovalLevelsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemApprovalLevelsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchBillingItemApprovalLevelsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -153,16 +148,16 @@ func searchBillingItemApprovalLevelsHandler(client *autotask.Client) func(ctx co
 
 		levels, err := autotask.List[entities.BillingItemApprovalLevel](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search billing item approval levels: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(levels) == 0 {
-			return textResult("No billing item approval levels found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(levels)
 		if err != nil {
-			return errorResult("failed to convert billing item approval levels: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, nil, maps, "autotask_search_billing_item_approval_levels", maxResults)

--- a/tools/billing_test.go
+++ b/tools/billing_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/autotask-mcp/services"
+	autotask "github.com/tphakala/go-autotask"
+	"github.com/tphakala/go-autotask/autotasktest"
+	"github.com/tphakala/go-autotask/entities"
 )
 
 // TestRegisterBillingTools_NoPanic verifies registration does not panic.
@@ -17,57 +19,119 @@ func TestRegisterBillingTools_NoPanic(t *testing.T) {
 	RegisterBillingTools(s, client, mapper)
 }
 
-// TestGetBillingItemHandler_NotFound tests that a missing billing item returns an error result.
+// TestGetBillingItemHandler_NotFound tests that a missing billing item returns an error result over wire.
 func TestGetBillingItemHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getBillingItemHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetBillingItemInput{BillingItemID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_billing_item",
+		Arguments: map[string]any{
+			"billingItemId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing billing item")
 	}
 }
 
-// TestSearchBillingItemsHandler_NoResults tests the empty-result case.
+// TestSearchBillingItemsHandler_NoResults tests the empty-result case over wire.
 func TestSearchBillingItemsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := services.NewMappingCache(client)
-	handler := searchBillingItemsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchBillingItemsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_billing_items",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false for no-results case")
+		t.Errorf("expected IsError=false for no-results case; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned billing items, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestSearchBillingItemApprovalLevelsHandler_NoResults tests the empty-result case.
+// TestSearchBillingItemApprovalLevelsHandler_NoResults tests the empty-result case over wire.
 func TestSearchBillingItemApprovalLevelsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchBillingItemApprovalLevelsHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchBillingItemApprovalLevelsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_billing_item_approval_levels",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false for no-results case")
+		t.Errorf("expected IsError=false for no-results case; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned approval levels, got %d", resp.Summary.Returned)
 	}
 }
+
+// TestGetBillingItemHandler_MissingId tests that billingItemId=0 returns a validation error.
+func TestGetBillingItemHandler_MissingId(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_billing_item",
+		Arguments: map[string]any{
+			"billingItemId": 0,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("expected IsError=true when billingItemId is 0")
+	}
+}
+
+// TestGetBillingItemHandler_Success tests retrieving a seeded billing item over wire.
+func TestGetBillingItemHandler_Success(t *testing.T) {
+	item := &entities.BillingItem{
+		ID:          autotask.Set(int64(9001)),
+		CompanyID:   autotask.Set(int64(1001)),
+		Description: autotask.Set("Monthly Support"),
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(item))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_billing_item",
+		Arguments: map[string]any{
+			"billingItemId": 9001,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	idVal, ok := m["id"]
+	if !ok {
+		t.Fatal("expected 'id' field in billing item response")
+	}
+	fVal, isFloat := idVal.(float64)
+	if !isFloat || int64(fVal) != 9001 {
+		t.Errorf("expected id=9001, got %v", idVal)
+	}
+}
+

--- a/tools/companies.go
+++ b/tools/companies.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -64,8 +63,8 @@ func RegisterCompanyTools(s *mcp.Server, client *autotask.Client, mapper *servic
 }
 
 // searchCompaniesHandler returns a handler that searches companies using the provided filters.
-func searchCompaniesHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompaniesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompaniesInput) (*mcp.CallToolResult, any, error) {
+func searchCompaniesHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompaniesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompaniesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 200)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -79,16 +78,16 @@ func searchCompaniesHandler(client *autotask.Client, mapper *services.MappingCac
 
 		companies, err := autotask.List[entities.Company](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search companies: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(companies) == 0 {
-			return textResult("No companies found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(companies)
 		if err != nil {
-			return errorResult("failed to convert companies: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_companies", maxResults)
@@ -96,8 +95,8 @@ func searchCompaniesHandler(client *autotask.Client, mapper *services.MappingCac
 }
 
 // createCompanyHandler returns a handler that creates a new company.
-func createCompanyHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyInput) (*mcp.CallToolResult, any, error) {
+func createCompanyHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyInput) (*mcp.CallToolResult, map[string]any, error) {
 		company := &entities.Company{
 			CompanyName: autotask.Set(in.CompanyName),
 			CompanyType: autotask.Set(int64(in.CompanyType)),
@@ -127,26 +126,21 @@ func createCompanyHandler(client *autotask.Client) func(ctx context.Context, req
 
 		created, err := autotask.Create[entities.Company](ctx, client, company)
 		if err != nil {
-			return errorResult("failed to create company: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created company: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created company: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // updateCompanyHandler returns a handler that updates an existing company.
-func updateCompanyHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateCompanyInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateCompanyInput) (*mcp.CallToolResult, any, error) {
+func updateCompanyHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateCompanyInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateCompanyInput) (*mcp.CallToolResult, map[string]any, error) {
 		company := &entities.Company{
 			ID: autotask.Set(in.ID),
 		}
@@ -175,19 +169,14 @@ func updateCompanyHandler(client *autotask.Client) func(ctx context.Context, req
 
 		updated, err := autotask.Update[entities.Company](ctx, client, company)
 		if err != nil {
-			return errorResult("failed to update company %d: %v", in.ID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(updated)
 		if err != nil {
-			return errorResult("failed to convert updated company: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal updated company: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/companies_test.go
+++ b/tools/companies_test.go
@@ -2,10 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -13,127 +14,95 @@ import (
 // three tools without panicking.
 func TestRegisterCompanyTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterCompanyTools(s, client, mapper)
 }
 
-// TestSearchCompaniesHandler_ReturnsNoCompaniesFound tests the empty-result case.
+// TestSearchCompaniesHandler_ReturnsNoCompaniesFound tests the empty-result case over wire.
 func TestSearchCompaniesHandler_ReturnsNoCompaniesFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchCompaniesHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchCompaniesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_companies",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned companies, got %d", resp.Summary.Returned)
 	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No companies found" {
-		t.Errorf("expected 'No companies found', got %q", text.Text)
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
 	}
 }
 
-// TestSearchCompaniesHandler_ReturnsCompanies tests that seeded companies are returned.
+// TestSearchCompaniesHandler_ReturnsCompanies tests that seeded companies are returned over wire.
 func TestSearchCompaniesHandler_ReturnsCompanies(t *testing.T) {
 	company := autotasktest.CompanyFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(company))
-	mapper := newTestMapper(client)
-
-	handler := searchCompaniesHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(company))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchCompaniesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_companies",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned company, got %d", resp.Summary.Returned)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
 	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one company in results")
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected company to contain 'id' field")
 	}
 }
 
-// TestCreateCompanyHandler_Success tests that a company can be created.
+// TestCreateCompanyHandler_Success tests creating a company over wire.
 func TestCreateCompanyHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.CompanyFixture()),
-	)
-
-	handler := createCompanyHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.CompanyFixture()))
 	ctx := context.Background()
 
-	in := CreateCompanyInput{
-		CompanyName: "Test Company",
-		CompanyType: 1,
-		Phone:       "555-1234",
-		City:        "Springfield",
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_company",
+		Arguments: map[string]any{
+			"companyName": "Test Company",
+			"companyType": 1,
+			"phone":       "555-1234",
+			"city":        "Springfield",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["companyName"].(string)
+	if !strings.Contains(nameStr, "Test Company") {
+		t.Errorf("expected companyName to contain 'Test Company', got %v", m["companyName"])
 	}
 }
 
-// TestUpdateCompanyHandler_Success tests that an existing company can be updated.
+// TestUpdateCompanyHandler_Success tests updating an existing company over wire.
 func TestUpdateCompanyHandler_Success(t *testing.T) {
 	company := autotasktest.CompanyFixture()
 	companyID, ok := company.ID.Get()
@@ -141,63 +110,50 @@ func TestUpdateCompanyHandler_Success(t *testing.T) {
 		t.Fatal("fixture company has no ID")
 	}
 
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(company))
-
-	handler := updateCompanyHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(company))
 	ctx := context.Background()
 
-	in := UpdateCompanyInput{
-		ID:          companyID,
-		CompanyName: "Updated Company Name",
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_update_company",
+		Arguments: map[string]any{
+			"id":          companyID,
+			"companyName": "Updated Company Name",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["companyName"].(string)
+	if !strings.Contains(nameStr, "Updated Company Name") {
+		t.Errorf("expected companyName to contain 'Updated Company Name', got %v", m["companyName"])
 	}
 }
 
-// TestSearchCompaniesHandler_WithFilters verifies that filters can be applied without error.
+// TestSearchCompaniesHandler_WithFilters verifies filters execution over wire.
 func TestSearchCompaniesHandler_WithFilters(t *testing.T) {
 	company := autotasktest.CompanyFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(company))
-	mapper := newTestMapper(client)
-
-	handler := searchCompaniesHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(company))
 	ctx := context.Background()
 
 	active := true
-	in := SearchCompaniesInput{
-		SearchTerm: "Acme",
-		IsActive:   &active,
-		MaxResults: 10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_companies",
+		Arguments: map[string]any{
+			"searchTerm": "Acme",
+			"isActive":   active,
+			"maxResults": 10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+

--- a/tools/config_items.go
+++ b/tools/config_items.go
@@ -28,8 +28,8 @@ func RegisterConfigItemTools(s *mcp.Server, client *autotask.Client, mapper *ser
 }
 
 // searchConfigurationItemsHandler returns a handler that searches configuration items.
-func searchConfigurationItemsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchConfigurationItemsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchConfigurationItemsInput) (*mcp.CallToolResult, any, error) {
+func searchConfigurationItemsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchConfigurationItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchConfigurationItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -48,16 +48,16 @@ func searchConfigurationItemsHandler(client *autotask.Client, mapper *services.M
 
 		items, err := autotask.List[entities.ConfigurationItem](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search configuration items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(items) == 0 {
-			return textResult("No configuration items found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(items)
 		if err != nil {
-			return errorResult("failed to convert configuration items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_configuration_items", maxResults)

--- a/tools/config_items_test.go
+++ b/tools/config_items_test.go
@@ -2,12 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/autotask-mcp/services"
+	"github.com/tphakala/go-autotask/autotasktest"
 )
 
 // TestRegisterConfigItemTools_NoPanic verifies registration does not panic.
@@ -18,81 +17,80 @@ func TestRegisterConfigItemTools_NoPanic(t *testing.T) {
 	RegisterConfigItemTools(s, client, mapper)
 }
 
-// TestSearchConfigurationItemsHandler_NoResults tests the empty-result case.
+// TestSearchConfigurationItemsHandler_NoResults tests the empty-result case over wire.
 func TestSearchConfigurationItemsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := services.NewMappingCache(client)
-	handler := searchConfigurationItemsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchConfigurationItemsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_configuration_items",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-}
-
-// TestSearchConfigurationItemsHandler_WithResults tests that seeded CIs are returned.
-func TestSearchConfigurationItemsHandler_WithResults(t *testing.T) {
-	ci := autotasktest.ConfigurationItemFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ci))
-	mapper := services.NewMappingCache(client)
-	handler := searchConfigurationItemsHandler(client, mapper)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchConfigurationItemsInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned items, got %d", resp.Summary.Returned)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one configuration item in results")
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
 	}
 }
 
-// TestSearchConfigurationItemsHandler_WithFilters verifies filters can be applied.
+// TestSearchConfigurationItemsHandler_WithResults tests that seeded CIs are returned over wire.
+func TestSearchConfigurationItemsHandler_WithResults(t *testing.T) {
+	ci := autotasktest.ConfigurationItemFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ci))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_configuration_items",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 item, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
+	}
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected CI to contain 'id' field")
+	}
+}
+
+// TestSearchConfigurationItemsHandler_WithFilters verifies filters can be applied over wire.
 func TestSearchConfigurationItemsHandler_WithFilters(t *testing.T) {
 	ci := autotasktest.ConfigurationItemFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ci))
-	mapper := services.NewMappingCache(client)
-	handler := searchConfigurationItemsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ci))
 	ctx := context.Background()
 
 	active := true
-	result, _, err := handler(ctx, nil, SearchConfigurationItemsInput{
-		SearchTerm: "PROD",
-		CompanyID:  1001,
-		IsActive:   &active,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_configuration_items",
+		Arguments: map[string]any{
+			"searchTerm": "PROD",
+			"companyID":  1001,
+			"isActive":   active,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
 }
+

--- a/tools/connection.go
+++ b/tools/connection.go
@@ -18,14 +18,20 @@ func RegisterConnectionTools(s *mcp.Server, client *autotask.Client) {
 }
 
 // testConnectionHandler returns a handler that tests the Autotask API connection.
-func testConnectionHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func testConnectionHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, ConnectionStatusOut, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, ConnectionStatusOut, error) {
 		info, err := metadata.GetEntityInfo(ctx, client, "Tickets")
 		if err != nil {
-			return errorResult("connection test failed: %v", err)
+			return nil, ConnectionStatusOut{}, err
 		}
 
-		return textResult("Connection successful. Tickets entity: canCreate=%v canUpdate=%v canQuery=%v",
-			info.CanCreate, info.CanUpdate, info.CanQuery)
+		return nil, ConnectionStatusOut{
+			Success:   true,
+			Entity:    "Tickets",
+			CanCreate: info.CanCreate,
+			CanUpdate: info.CanUpdate,
+			CanQuery:  info.CanQuery,
+			Message: "Connection successful",
+		}, nil
 	}
 }

--- a/tools/connection_test.go
+++ b/tools/connection_test.go
@@ -15,31 +15,45 @@ func TestRegisterConnectionTools_NoPanic(t *testing.T) {
 	RegisterConnectionTools(s, client)
 }
 
-// TestTestConnectionHandler_Success tests that connection succeeds against the mock server.
-func TestTestConnectionHandler_Success(t *testing.T) {
+// TestTestConnectionHandler_Direct tests handler logic directly.
+func TestTestConnectionHandler_Direct(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
 	handler := testConnectionHandler(client)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, struct{}{})
+	res, out, err := handler(ctx, nil, struct{}{})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if res != nil {
+		t.Errorf("expected nil *CallToolResult for SDK inference, got %v", res)
 	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text == "" {
-		t.Error("expected non-empty connection result text")
+	if !out.Success || out.Entity != "Tickets" {
+		t.Errorf("unexpected output: %+v", out)
 	}
 }
+
+// TestTestConnectionHandler_Wire tests that connection succeeds against the mock server over wire protocol.
+func TestTestConnectionHandler_Wire(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_test_connection",
+	})
+	if err != nil {
+		t.Fatalf("wire call failed: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	out := parseStructuredContent[ConnectionStatusOut](t, result)
+	if !out.Success {
+		t.Errorf("expected Success=true, got %v", out.Success)
+	}
+	if out.Entity != "Tickets" {
+		t.Errorf("expected Entity=Tickets, got %q", out.Entity)
+	}
+}
+

--- a/tools/contacts.go
+++ b/tools/contacts.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -44,8 +43,8 @@ func RegisterContactTools(s *mcp.Server, client *autotask.Client, mapper *servic
 }
 
 // searchContactsHandler returns a handler that searches contacts using the provided filters.
-func searchContactsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchContactsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchContactsInput) (*mcp.CallToolResult, any, error) {
+func searchContactsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchContactsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchContactsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 200)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -66,16 +65,16 @@ func searchContactsHandler(client *autotask.Client, mapper *services.MappingCach
 
 		contacts, err := autotask.List[entities.Contact](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search contacts: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(contacts) == 0 {
-			return textResult("No contacts found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(contacts)
 		if err != nil {
-			return errorResult("failed to convert contacts: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_contacts", maxResults)
@@ -83,8 +82,8 @@ func searchContactsHandler(client *autotask.Client, mapper *services.MappingCach
 }
 
 // createContactHandler returns a handler that creates a new contact.
-func createContactHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateContactInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateContactInput) (*mcp.CallToolResult, any, error) {
+func createContactHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateContactInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateContactInput) (*mcp.CallToolResult, map[string]any, error) {
 		contact := &entities.Contact{
 			CompanyID: autotask.Set(in.CompanyID),
 			FirstName: autotask.Set(in.FirstName),
@@ -103,19 +102,14 @@ func createContactHandler(client *autotask.Client) func(ctx context.Context, req
 
 		created, err := autotask.Create[entities.Contact](ctx, client, contact)
 		if err != nil {
-			return errorResult("failed to create contact: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created contact: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created contact: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/contacts_test.go
+++ b/tools/contacts_test.go
@@ -2,10 +2,10 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -13,149 +13,114 @@ import (
 // two tools without panicking.
 func TestRegisterContactTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterContactTools(s, client, mapper)
 }
 
-// TestSearchContactsHandler_ReturnsNoContactsFound tests the empty-result case.
+// TestSearchContactsHandler_ReturnsNoContactsFound tests the empty-result case over wire.
 func TestSearchContactsHandler_ReturnsNoContactsFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchContactsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchContactsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_contacts",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned contacts, got %d", resp.Summary.Returned)
 	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No contacts found" {
-		t.Errorf("expected 'No contacts found', got %q", text.Text)
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
 	}
 }
 
-// TestSearchContactsHandler_ReturnsContacts tests that seeded contacts are returned.
+// TestSearchContactsHandler_ReturnsContacts tests that seeded contacts are returned over wire.
 func TestSearchContactsHandler_ReturnsContacts(t *testing.T) {
 	contact := autotasktest.ContactFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(contact))
-	mapper := newTestMapper(client)
-
-	handler := searchContactsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(contact))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchContactsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_contacts",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned contact, got %d", resp.Summary.Returned)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
 	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one contact in results")
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected contact to contain 'id' field")
 	}
 }
 
-// TestCreateContactHandler_Success tests that a contact can be created.
+// TestCreateContactHandler_Success tests creating a contact over wire.
 func TestCreateContactHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.ContactFixture()),
-	)
-
-	handler := createContactHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.ContactFixture()))
 	ctx := context.Background()
 
-	in := CreateContactInput{
-		CompanyID:    1001,
-		FirstName:    "Alice",
-		LastName:     "Example",
-		EmailAddress: "alice@example.com",
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_contact",
+		Arguments: map[string]any{
+			"companyID":    1001,
+			"firstName":    "Alice",
+			"lastName":     "Example",
+			"emailAddress": "alice@example.com",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	if m["firstName"] != "Alice" {
+		t.Errorf("expected firstName='Alice', got %v", m["firstName"])
 	}
 }
 
-// TestSearchContactsHandler_WithFilters verifies that multiple filters can be applied.
+// TestSearchContactsHandler_WithFilters verifies filters execution over wire.
 func TestSearchContactsHandler_WithFilters(t *testing.T) {
 	contact := autotasktest.ContactFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(contact))
-	mapper := newTestMapper(client)
-
-	handler := searchContactsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(contact))
 	ctx := context.Background()
 
 	active := 1
-	in := SearchContactsInput{
-		SearchTerm: "Jane",
-		CompanyID:  1001,
-		IsActive:   &active,
-		MaxResults: 10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_contacts",
+		Arguments: map[string]any{
+			"searchTerm": "Jane",
+			"companyID":  1001,
+			"isActive":   active,
+			"maxResults": 10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+

--- a/tools/expenses.go
+++ b/tools/expenses.go
@@ -2,9 +2,9 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/entities"
 )
@@ -70,30 +70,25 @@ func RegisterExpenseTools(s *mcp.Server, client *autotask.Client) {
 }
 
 // getExpenseReportHandler returns a handler that retrieves a single expense report.
-func getExpenseReportHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetExpenseReportInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetExpenseReportInput) (*mcp.CallToolResult, any, error) {
+func getExpenseReportHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetExpenseReportInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetExpenseReportInput) (*mcp.CallToolResult, map[string]any, error) {
 		report, err := autotask.Get[entities.ExpenseReport](ctx, client, in.ReportID)
 		if err != nil {
-			return errorResult("failed to get expense report %d: %v", in.ReportID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(report)
 		if err != nil {
-			return errorResult("failed to convert expense report: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal expense report: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchExpenseReportsHandler returns a handler that searches expense reports.
-func searchExpenseReportsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchExpenseReportsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchExpenseReportsInput) (*mcp.CallToolResult, any, error) {
+func searchExpenseReportsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchExpenseReportsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchExpenseReportsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -106,33 +101,28 @@ func searchExpenseReportsHandler(client *autotask.Client) func(ctx context.Conte
 
 		reports, err := autotask.List[entities.ExpenseReport](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search expense reports: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(reports) == 0 {
-			return textResult("No expense reports found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(reports)
 		if err != nil {
-			return errorResult("failed to convert expense reports: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal expense reports: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_expense_reports", maxResults)
 	}
 }
 
 // createExpenseReportHandler returns a handler that creates a new expense report.
-func createExpenseReportHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseReportInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseReportInput) (*mcp.CallToolResult, any, error) {
+func createExpenseReportHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseReportInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseReportInput) (*mcp.CallToolResult, map[string]any, error) {
 		weekEnding, err := parseDate(in.WeekEndingDate)
 		if err != nil {
-			return errorResult("invalid weekEndingDate format (expected YYYY-MM-DD or ISO format): %v", err)
+			return nil, nil, err
 		}
 
 		entity := &entities.ExpenseReport{
@@ -142,29 +132,24 @@ func createExpenseReportHandler(client *autotask.Client) func(ctx context.Contex
 		}
 		created, err := autotask.Create[entities.ExpenseReport](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to create expense report: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created expense report: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created expense report: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // createExpenseItemHandler returns a handler that creates a new expense item.
-func createExpenseItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseItemInput) (*mcp.CallToolResult, any, error) {
+func createExpenseItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseItemInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateExpenseItemInput) (*mcp.CallToolResult, map[string]any, error) {
 		expenseDate, err := parseDate(in.ExpenseDate)
 		if err != nil {
-			return errorResult("invalid expenseDate format (expected YYYY-MM-DD or ISO format): %v", err)
+			return nil, nil, err
 		}
 
 		entity := &entities.ExpenseItem{
@@ -192,19 +177,14 @@ func createExpenseItemHandler(client *autotask.Client) func(ctx context.Context,
 
 		created, err := autotask.Create[entities.ExpenseItem](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to create expense item: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created expense item: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created expense item: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/expenses_test.go
+++ b/tools/expenses_test.go
@@ -2,9 +2,11 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -15,132 +17,146 @@ func TestRegisterExpenseTools_NoPanic(t *testing.T) {
 	RegisterExpenseTools(s, client)
 }
 
-// TestGetExpenseReportHandler_NotFound tests that a missing report returns an error result.
+// TestGetExpenseReportHandler_NotFound tests that a missing report returns an error result over wire.
 func TestGetExpenseReportHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getExpenseReportHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetExpenseReportInput{ReportID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_expense_report",
+		Arguments: map[string]any{
+			"reportId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing expense report")
 	}
 }
 
-// TestSearchExpenseReportsHandler_NoResults tests the empty-result case.
+// TestSearchExpenseReportsHandler_NoResults tests the empty-result case over wire.
 func TestSearchExpenseReportsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchExpenseReportsHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchExpenseReportsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_expense_reports",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result for empty search, got IsError=true")
+		t.Errorf("expected no error result for empty search, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned reports, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestCreateExpenseReportHandler_InvalidDate tests that an invalid date returns an error result.
+// TestCreateExpenseReportHandler_InvalidDate tests that an invalid date returns an error result over wire.
 func TestCreateExpenseReportHandler_InvalidDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createExpenseReportHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateExpenseReportInput{
-		Name:           "Test Report",
-		SubmitterID:    5001,
-		WeekEndingDate: "not-a-date",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_expense_report",
+		Arguments: map[string]any{
+			"name":           "Test Report",
+			"submitterId":    5001,
+			"weekEndingDate": "not-a-date",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestCreateExpenseReportHandler_Success tests that an expense report can be created.
+// TestCreateExpenseReportHandler_Success tests creating an expense report over wire.
 func TestCreateExpenseReportHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createExpenseReportHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateExpenseReportInput{
-		Name:           "Weekly Expense Report",
-		SubmitterID:    5001,
-		WeekEndingDate: "2024-01-19",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_expense_report",
+		Arguments: map[string]any{
+			"name":           "Weekly Expense Report",
+			"submitterId":    5001,
+			"weekEndingDate": "2024-01-19",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["name"].(string)
+	if !strings.Contains(nameStr, "Weekly Expense Report") {
+		t.Errorf("expected name to contain 'Weekly Expense Report', got %v", m["name"])
 	}
 }
 
-// TestCreateExpenseItemHandler_InvalidDate tests that an invalid expense date returns an error result.
+// TestCreateExpenseItemHandler_InvalidDate tests that an invalid expense date returns an error result over wire.
 func TestCreateExpenseItemHandler_InvalidDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createExpenseItemHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateExpenseItemInput{
-		ExpenseReportID: 1,
-		Description:     "Lunch",
-		ExpenseDate:     "bad-date",
-		ExpenseCategory: 1,
-		Amount:          15.50,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_expense_item",
+		Arguments: map[string]any{
+			"expenseReportId": 1,
+			"description":     "Lunch",
+			"expenseDate":     "bad-date",
+			"expenseCategory": 1,
+			"amount":          15.50,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestCreateExpenseItemHandler_Success tests that an expense item can be created.
+// TestCreateExpenseItemHandler_Success tests creating an expense item over wire.
 func TestCreateExpenseItemHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createExpenseItemHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateExpenseItemInput{
-		ExpenseReportID:     1,
-		Description:         "Team lunch",
-		ExpenseDate:         "2024-01-15",
-		ExpenseCategory:     1,
-		Amount:              45.00,
-		IsBillableToCompany: true,
-		IsReimbursable:      true,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_expense_item",
+		Arguments: map[string]any{
+			"expenseReportId":     1,
+			"description":         "Team lunch",
+			"expenseDate":         "2024-01-15",
+			"expenseCategory":     1,
+			"amount":              45.00,
+			"isBillableToCompany": true,
+			"isReimbursable":      true,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	descStr, _ := m["description"].(string)
+	if !strings.Contains(descStr, "Team lunch") {
+		t.Errorf("expected description to contain 'Team lunch', got %v", m["description"])
 	}
 }
+

--- a/tools/financial.go
+++ b/tools/financial.go
@@ -2,7 +2,7 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -229,30 +229,25 @@ func RegisterFinancialTools(s *mcp.Server, client *autotask.Client, mapper *serv
 }
 
 // getQuoteHandler returns a handler that retrieves a single quote.
-func getQuoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteInput) (*mcp.CallToolResult, any, error) {
+func getQuoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		quote, err := autotask.Get[entities.Quote](ctx, client, in.QuoteID)
 		if err != nil {
-			return errorResult("failed to get quote %d: %v", in.QuoteID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(quote)
 		if err != nil {
-			return errorResult("failed to convert quote: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal quote: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchQuotesHandler returns a handler that searches quotes.
-func searchQuotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuotesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuotesInput) (*mcp.CallToolResult, any, error) {
+func searchQuotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -271,30 +266,25 @@ func searchQuotesHandler(client *autotask.Client) func(ctx context.Context, req 
 
 		quotes, err := autotask.List[entities.Quote](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search quotes: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(quotes) == 0 {
-			return textResult("No quotes found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(quotes)
 		if err != nil {
-			return errorResult("failed to convert quotes: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal quotes: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_quotes", maxResults)
 	}
 }
 
 // createQuoteHandler returns a handler that creates a new quote.
-func createQuoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteInput) (*mcp.CallToolResult, any, error) {
+func createQuoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		entity := &entities.Quote{
 			CompanyID: autotask.Set(in.CompanyID),
 		}
@@ -313,62 +303,52 @@ func createQuoteHandler(client *autotask.Client) func(ctx context.Context, req *
 		if in.EffectiveDate != "" {
 			t, err := parseDate(in.EffectiveDate)
 			if err != nil {
-				return errorResult("invalid effectiveDate format: %v", err)
+				return nil, nil, err
 			}
 			entity.EffectiveDate = autotask.Set(t)
 		}
 		if in.ExpirationDate != "" {
 			t, err := parseDate(in.ExpirationDate)
 			if err != nil {
-				return errorResult("invalid expirationDate format: %v", err)
+				return nil, nil, err
 			}
 			entity.ExpirationDate = autotask.Set(t)
 		}
 
 		created, err := autotask.Create[entities.Quote](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to create quote: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created quote: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created quote: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // getQuoteItemHandler returns a handler that retrieves a single quote item.
-func getQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteItemInput) (*mcp.CallToolResult, any, error) {
+func getQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
 		item, err := autotask.Get[entities.QuoteItem](ctx, client, in.QuoteItemID)
 		if err != nil {
-			return errorResult("failed to get quote item %d: %v", in.QuoteItemID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(item)
 		if err != nil {
-			return errorResult("failed to convert quote item: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal quote item: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchQuoteItemsHandler returns a handler that searches quote items.
-func searchQuoteItemsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuoteItemsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuoteItemsInput) (*mcp.CallToolResult, any, error) {
+func searchQuoteItemsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuoteItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchQuoteItemsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -381,30 +361,25 @@ func searchQuoteItemsHandler(client *autotask.Client) func(ctx context.Context, 
 
 		items, err := autotask.List[entities.QuoteItem](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search quote items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(items) == 0 {
-			return textResult("No quote items found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(items)
 		if err != nil {
-			return errorResult("failed to convert quote items: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal quote items: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_quote_items", maxResults)
 	}
 }
 
 // createQuoteItemHandler returns a handler that creates a new quote item.
-func createQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteItemInput) (*mcp.CallToolResult, any, error) {
+func createQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
 		entity := &entities.QuoteItem{
 			QuoteID:  autotask.Set(in.QuoteID),
 			Quantity: autotask.Set(in.Quantity),
@@ -448,7 +423,6 @@ func createQuoteItemHandler(client *autotask.Client) func(ctx context.Context, r
 		}
 
 		// Auto-determine quoteItemType if not provided.
-		// Autotask quote item type constants.
 		const (
 			quoteItemProduct       = 1
 			quoteItemService       = 11
@@ -471,26 +445,21 @@ func createQuoteItemHandler(client *autotask.Client) func(ctx context.Context, r
 
 		created, err := autotask.Create[entities.QuoteItem](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to create quote item: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created quote item: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created quote item: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // updateQuoteItemHandler returns a handler that updates an existing quote item.
-func updateQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateQuoteItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateQuoteItemInput) (*mcp.CallToolResult, any, error) {
+func updateQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateQuoteItemInput) (*mcp.CallToolResult, map[string]any, error) {
 		entity := &entities.QuoteItem{
 			ID: autotask.Set(in.QuoteItemID),
 		}
@@ -519,59 +488,53 @@ func updateQuoteItemHandler(client *autotask.Client) func(ctx context.Context, r
 
 		updated, err := autotask.Update[entities.QuoteItem](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to update quote item %d: %v", in.QuoteItemID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(updated)
 		if err != nil {
-			return errorResult("failed to convert updated quote item: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal updated quote item: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // deleteQuoteItemHandler returns a handler that deletes a quote item.
-func deleteQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in DeleteQuoteItemInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in DeleteQuoteItemInput) (*mcp.CallToolResult, any, error) {
+func deleteQuoteItemHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in DeleteQuoteItemInput) (*mcp.CallToolResult, DeleteResultOut, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in DeleteQuoteItemInput) (*mcp.CallToolResult, DeleteResultOut, error) {
 		if err := autotask.Delete[entities.QuoteItem](ctx, client, in.QuoteItemID); err != nil {
-			return errorResult("failed to delete quote item %d: %v", in.QuoteItemID, err)
+			return nil, DeleteResultOut{}, err
 		}
 
-		return textResult("Quote item %d deleted successfully", in.QuoteItemID)
+		return nil, DeleteResultOut{
+			Success: true,
+			ID:      in.QuoteItemID,
+			Message: fmt.Sprintf("Quote item %d deleted successfully", in.QuoteItemID),
+		}, nil
 	}
 }
 
 // getOpportunityHandler returns a handler that retrieves a single opportunity.
-func getOpportunityHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetOpportunityInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetOpportunityInput) (*mcp.CallToolResult, any, error) {
+func getOpportunityHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetOpportunityInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetOpportunityInput) (*mcp.CallToolResult, map[string]any, error) {
 		opp, err := autotask.Get[entities.Opportunity](ctx, client, in.OpportunityID)
 		if err != nil {
-			return errorResult("failed to get opportunity %d: %v", in.OpportunityID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(opp)
 		if err != nil {
-			return errorResult("failed to convert opportunity: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal opportunity: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchOpportunitiesHandler returns a handler that searches opportunities.
-func searchOpportunitiesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchOpportunitiesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchOpportunitiesInput) (*mcp.CallToolResult, any, error) {
+func searchOpportunitiesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchOpportunitiesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchOpportunitiesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -587,37 +550,32 @@ func searchOpportunitiesHandler(client *autotask.Client) func(ctx context.Contex
 
 		opps, err := autotask.List[entities.Opportunity](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search opportunities: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(opps) == 0 {
-			return textResult("No opportunities found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(opps)
 		if err != nil {
-			return errorResult("failed to convert opportunities: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal opportunities: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_opportunities", maxResults)
 	}
 }
 
 // createOpportunityHandler returns a handler that creates a new opportunity.
-func createOpportunityHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateOpportunityInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateOpportunityInput) (*mcp.CallToolResult, any, error) {
+func createOpportunityHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateOpportunityInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateOpportunityInput) (*mcp.CallToolResult, map[string]any, error) {
 		projectedClose, err := parseDate(in.ProjectedCloseDate)
 		if err != nil {
-			return errorResult("invalid projectedCloseDate format: %v", err)
+			return nil, nil, err
 		}
 		startDate, err := parseDate(in.StartDate)
 		if err != nil {
-			return errorResult("invalid startDate format: %v", err)
+			return nil, nil, err
 		}
 
 		entity := &entities.Opportunity{
@@ -657,26 +615,21 @@ func createOpportunityHandler(client *autotask.Client) func(ctx context.Context,
 
 		created, err := autotask.Create[entities.Opportunity](ctx, client, entity)
 		if err != nil {
-			return errorResult("failed to create opportunity: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created opportunity: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created opportunity: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchInvoicesHandler returns a handler that searches invoices.
-func searchInvoicesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchInvoicesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchInvoicesInput) (*mcp.CallToolResult, any, error) {
+func searchInvoicesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchInvoicesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchInvoicesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -692,30 +645,25 @@ func searchInvoicesHandler(client *autotask.Client) func(ctx context.Context, re
 
 		invoices, err := autotask.List[entities.Invoice](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search invoices: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(invoices) == 0 {
-			return textResult("No invoices found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(invoices)
 		if err != nil {
-			return errorResult("failed to convert invoices: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal invoices: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_invoices", maxResults)
 	}
 }
 
 // searchContractsHandler returns a handler that searches contracts.
-func searchContractsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchContractsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchContractsInput) (*mcp.CallToolResult, any, error) {
+func searchContractsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchContractsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchContractsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -731,16 +679,16 @@ func searchContractsHandler(client *autotask.Client, mapper *services.MappingCac
 
 		contracts, err := autotask.List[entities.Contract](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search contracts: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(contracts) == 0 {
-			return textResult("No contracts found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(contracts)
 		if err != nil {
-			return errorResult("failed to convert contracts: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_contracts", maxResults)

--- a/tools/financial_test.go
+++ b/tools/financial_test.go
@@ -2,11 +2,14 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/autotask-mcp/services"
+	autotask "github.com/tphakala/go-autotask"
+	"github.com/tphakala/go-autotask/autotasktest"
+	"github.com/tphakala/go-autotask/entities"
 )
 
 // TestRegisterFinancialTools_NoPanic verifies registration does not panic.
@@ -17,255 +20,326 @@ func TestRegisterFinancialTools_NoPanic(t *testing.T) {
 	RegisterFinancialTools(s, client, mapper)
 }
 
-// TestGetQuoteHandler_NotFound tests that a missing quote returns an error result.
+// TestGetQuoteHandler_NotFound tests that a missing quote returns an error result over wire.
 func TestGetQuoteHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getQuoteHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetQuoteInput{QuoteID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_quote",
+		Arguments: map[string]any{
+			"quoteId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing quote")
 	}
 }
 
-// TestSearchQuotesHandler_NoResults tests the empty-result case.
-func TestSearchQuotesHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchQuotesHandler(client)
+// TestGetQuoteHandler_Success tests retrieving a seeded quote over wire.
+func TestGetQuoteHandler_Success(t *testing.T) {
+	quote := &entities.Quote{
+		ID:        autotask.Set(int64(6001)),
+		CompanyID: autotask.Set(int64(1001)),
+		Name:      autotask.Set("Standard Quote"),
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(quote))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchQuotesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_quote",
+		Arguments: map[string]any{
+			"quoteId": 6001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["name"].(string)
+	if !strings.Contains(nameStr, "Quote") {
+		t.Errorf("expected name to contain 'Quote', got %v", m["name"])
 	}
 }
 
-// TestCreateQuoteHandler_Success tests that a quote can be created.
-func TestCreateQuoteHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createQuoteHandler(client)
+// TestSearchQuotesHandler_NoResults tests the empty-result case over wire.
+func TestSearchQuotesHandler_NoResults(t *testing.T) {
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateQuoteInput{
-		CompanyID: 1001,
-		Name:      "Q-2024-001",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_quotes",
+		Arguments: map[string]any{},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned quotes, got %d", resp.Summary.Returned)
+	}
 }
 
-// TestCreateQuoteHandler_InvalidEffectiveDate tests that an invalid date returns an error result.
-func TestCreateQuoteHandler_InvalidEffectiveDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createQuoteHandler(client)
+// TestCreateQuoteHandler_Success tests creating a quote over wire.
+func TestCreateQuoteHandler_Success(t *testing.T) {
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateQuoteInput{
-		CompanyID:     1001,
-		EffectiveDate: "not-a-date",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_quote",
+		Arguments: map[string]any{
+			"companyId": 1001,
+			"name":      "Q-2024-001",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["name"].(string)
+	if !strings.Contains(nameStr, "Q-2024-001") {
+		t.Errorf("expected name to contain 'Q-2024-001', got %v", m["name"])
+	}
+}
+
+// TestCreateQuoteHandler_InvalidEffectiveDate tests that an invalid date returns an error result over wire.
+func TestCreateQuoteHandler_InvalidEffectiveDate(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_quote",
+		Arguments: map[string]any{
+			"companyId":     1001,
+			"effectiveDate": "not-a-date",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestCreateQuoteItemHandler_AutoDeterminesType tests that the quote item type is auto-determined.
+// TestCreateQuoteItemHandler_AutoDeterminesType tests creating a quote item over wire.
 func TestCreateQuoteItemHandler_AutoDeterminesType(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createQuoteItemHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	// Product ID → type 1
-	result, _, err := handler(ctx, nil, CreateQuoteItemInput{
-		QuoteID:   101,
-		Quantity:  2,
-		ProductID: 5001,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_quote_item",
+		Arguments: map[string]any{
+			"quoteId":   101,
+			"quantity":  2,
+			"productID": 5001,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result for product quote item, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected no error result for product quote item, got IsError=true; content: %v", result.Content)
 	}
 }
 
-// TestDeleteQuoteItemHandler_NotFound tests that deleting a missing quote item returns an error.
+// TestDeleteQuoteItemHandler_NotFound tests that deleting a missing quote item returns an error over wire.
 func TestDeleteQuoteItemHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := deleteQuoteItemHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, DeleteQuoteItemInput{QuoteID: 101, QuoteItemID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_delete_quote_item",
+		Arguments: map[string]any{
+			"quoteId":     101,
+			"quoteItemId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing quote item")
 	}
 }
 
-// TestGetOpportunityHandler_NotFound tests that a missing opportunity returns an error result.
+// TestGetOpportunityHandler_NotFound tests that a missing opportunity returns an error result over wire.
 func TestGetOpportunityHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getOpportunityHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetOpportunityInput{OpportunityID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_opportunity",
+		Arguments: map[string]any{
+			"opportunityId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing opportunity")
 	}
 }
 
-// TestSearchOpportunitiesHandler_NoResults tests the empty-result case.
+// TestSearchOpportunitiesHandler_NoResults tests the empty-result case over wire.
 func TestSearchOpportunitiesHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchOpportunitiesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchOpportunitiesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_opportunities",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned opportunities, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestCreateOpportunityHandler_InvalidDate tests that an invalid date returns an error result.
+// TestCreateOpportunityHandler_InvalidDate tests that an invalid date returns an error result over wire.
 func TestCreateOpportunityHandler_InvalidDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createOpportunityHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateOpportunityInput{
-		Title:              "Big Deal",
-		CompanyID:          1001,
-		OwnerResourceID:    5001,
-		Status:             1,
-		Stage:              1,
-		ProjectedCloseDate: "not-a-date",
-		StartDate:          "2024-01-01",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_opportunity",
+		Arguments: map[string]any{
+			"title":              "Big Deal",
+			"companyId":          1001,
+			"ownerResourceId":    5001,
+			"status":             1,
+			"stage":              1,
+			"projectedCloseDate": "not-a-date",
+			"startDate":          "2024-01-01",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestCreateOpportunityHandler_Success tests that an opportunity can be created.
+// TestCreateOpportunityHandler_Success tests creating an opportunity over wire.
 func TestCreateOpportunityHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := createOpportunityHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateOpportunityInput{
-		Title:              "Big Deal",
-		CompanyID:          1001,
-		OwnerResourceID:    5001,
-		Status:             1,
-		Stage:              1,
-		ProjectedCloseDate: "2024-06-30",
-		StartDate:          "2024-01-15",
-		Amount:             50000,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_opportunity",
+		Arguments: map[string]any{
+			"title":              "Big Deal",
+			"companyId":          1001,
+			"ownerResourceId":    5001,
+			"status":             1,
+			"stage":              1,
+			"projectedCloseDate": "2024-06-30",
+			"startDate":          "2024-01-15",
+			"amount":             50000,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "Big Deal") {
+		t.Errorf("expected title to contain 'Big Deal', got %v", m["title"])
+	}
+}
+
+// TestSearchContractsHandler_NoResults tests the empty-result case over wire.
+func TestSearchContractsHandler_NoResults(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_contracts",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-}
 
-// TestSearchContractsHandler_NoResults tests the empty-result case.
-func TestSearchContractsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := services.NewMappingCache(client)
-	handler := searchContractsHandler(client, mapper)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchContractsInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned contracts, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestSearchContractsHandler_WithResults tests that seeded contracts are returned.
+// TestSearchContractsHandler_WithResults tests that seeded contracts are returned over wire.
 func TestSearchContractsHandler_WithResults(t *testing.T) {
 	contract := autotasktest.ContractFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(contract))
-	mapper := services.NewMappingCache(client)
-	handler := searchContractsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(contract))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchContractsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_contracts",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned contract, got %d", resp.Summary.Returned)
+	}
+}
+
+// TestSearchInvoicesHandler_NoResults tests the empty-result case for invoices over wire.
+func TestSearchInvoicesHandler_NoResults(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_invoices",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-}
 
-// TestSearchInvoicesHandler_NoResults tests the empty-result case for invoices.
-func TestSearchInvoicesHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchInvoicesHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchInvoicesInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned invoices, got %d", resp.Summary.Returned)
 	}
 }
+

--- a/tools/lazy.go
+++ b/tools/lazy.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -175,22 +176,26 @@ type RouterInput struct {
 type ToolRunner func(ctx context.Context, rawArgs map[string]any) (*mcp.CallToolResult, any, error)
 
 // makeRunner converts a typed MCP tool handler into a dynamic ToolRunner.
-func makeRunner[In any](handler func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, any, error)) ToolRunner {
+func makeRunner[In, Out any](handler func(context.Context, *mcp.CallToolRequest, In) (*mcp.CallToolResult, Out, error)) ToolRunner {
 	return func(ctx context.Context, rawArgs map[string]any) (*mcp.CallToolResult, any, error) {
 		if handler == nil {
-			return errorResult("tool handler is not configured")
+			return nil, nil, fmt.Errorf("tool handler is not configured")
 		}
 		var in In
 		if len(rawArgs) > 0 {
 			data, err := json.Marshal(rawArgs)
 			if err != nil {
-				return errorResult("failed to encode tool arguments: %v", err)
+				return nil, nil, fmt.Errorf("failed to encode tool arguments: %w", err)
 			}
 			if err := json.Unmarshal(data, &in); err != nil {
-				return errorResult("failed to decode arguments into target parameter schema: %v", err)
+				return nil, nil, fmt.Errorf("failed to decode arguments into target parameter schema: %w", err)
 			}
 		}
-		return handler(ctx, nil, in)
+		res, out, err := handler(ctx, &mcp.CallToolRequest{}, in)
+		if err != nil {
+			return nil, nil, err
+		}
+		return res, out, nil
 	}
 }
 
@@ -206,6 +211,12 @@ func buildToolDispatcher(client *autotask.Client, mapper *services.MappingCache,
 		"autotask_list_ticket_priorities": makeRunner(listTicketPrioritiesHandler(picklist)),
 		"autotask_get_field_info":         makeRunner(getFieldInfoHandler(picklist)),
 
+		// Tickets
+		"autotask_search_tickets":     makeRunner(searchTicketsHandler(client, mapper)),
+		"autotask_get_ticket_details": makeRunner(getTicketDetailsHandler(client, mapper)),
+		"autotask_create_ticket":      makeRunner(createTicketHandler(client)),
+		"autotask_update_ticket":      makeRunner(updateTicketHandler(client)),
+
 		// Companies
 		"autotask_search_companies": makeRunner(searchCompaniesHandler(client, mapper)),
 		"autotask_create_company":   makeRunner(createCompanyHandler(client)),
@@ -215,13 +226,25 @@ func buildToolDispatcher(client *autotask.Client, mapper *services.MappingCache,
 		"autotask_search_contacts": makeRunner(searchContactsHandler(client, mapper)),
 		"autotask_create_contact":  makeRunner(createContactHandler(client)),
 
-		// Tickets
-		"autotask_search_tickets":     makeRunner(searchTicketsHandler(client, mapper)),
-		"autotask_get_ticket_details": makeRunner(getTicketDetailsHandler(client, mapper)),
-		"autotask_create_ticket":      makeRunner(createTicketHandler(client)),
-		"autotask_update_ticket":      makeRunner(updateTicketHandler(client)),
+		// Projects
+		"autotask_search_projects": makeRunner(searchProjectsHandler(client, mapper)),
+		"autotask_create_project":  makeRunner(createProjectHandler(client)),
 
-		// Notes
+		// Tasks
+		"autotask_search_tasks": makeRunner(searchTasksHandler(client, mapper)),
+		"autotask_create_task":  makeRunner(createTaskHandler(client)),
+
+		// Time entries
+		"autotask_search_time_entries": makeRunner(searchTimeEntriesHandler(client, mapper)),
+		"autotask_create_time_entry":   makeRunner(createTimeEntryHandler(client)),
+
+		// Resources
+		"autotask_search_resources": makeRunner(searchResourcesHandler(client)),
+
+		// Configuration items
+		"autotask_search_configuration_items": makeRunner(searchConfigurationItemsHandler(client, mapper)),
+
+		// Company, ticket, and project notes
 		"autotask_get_ticket_note":      makeRunner(getTicketNoteHandler(client)),
 		"autotask_search_ticket_notes":  makeRunner(searchTicketNotesHandler(client)),
 		"autotask_create_ticket_note":   makeRunner(createTicketNoteHandler(client)),
@@ -232,45 +255,22 @@ func buildToolDispatcher(client *autotask.Client, mapper *services.MappingCache,
 		"autotask_search_company_notes": makeRunner(searchCompanyNotesHandler(client)),
 		"autotask_create_company_note":  makeRunner(createCompanyNoteHandler(client)),
 
-		// Attachments
+		// Ticket attachments
 		"autotask_get_ticket_attachment":     makeRunner(getTicketAttachmentHandler(client)),
 		"autotask_search_ticket_attachments": makeRunner(searchTicketAttachmentsHandler(client)),
 
-		// Projects
-		"autotask_search_projects": makeRunner(searchProjectsHandler(client, mapper)),
-		"autotask_create_project":  makeRunner(createProjectHandler(client)),
-
-		// Tasks
-		"autotask_search_tasks": makeRunner(searchTasksHandler(client, mapper)),
-		"autotask_create_task":  makeRunner(createTaskHandler(client)),
-
-		// Time and Billing
-		"autotask_create_time_entry":                   makeRunner(createTimeEntryHandler(client)),
-		"autotask_search_time_entries":                 makeRunner(searchTimeEntriesHandler(client, mapper)),
-		"autotask_search_billing_items":                makeRunner(searchBillingItemsHandler(client, mapper)),
-		"autotask_get_billing_item":                    makeRunner(getBillingItemHandler(client)),
+		// Billing
+		"autotask_get_billing_item":                   makeRunner(getBillingItemHandler(client)),
+		"autotask_search_billing_items":               makeRunner(searchBillingItemsHandler(client, mapper)),
 		"autotask_search_billing_item_approval_levels": makeRunner(searchBillingItemApprovalLevelsHandler(client)),
-		"autotask_get_expense_report":                  makeRunner(getExpenseReportHandler(client)),
-		"autotask_search_expense_reports":              makeRunner(searchExpenseReportsHandler(client)),
-		"autotask_create_expense_report":               makeRunner(createExpenseReportHandler(client)),
-		"autotask_create_expense_item":                 makeRunner(createExpenseItemHandler(client)),
 
-		// Financial
-		"autotask_get_quote":            makeRunner(getQuoteHandler(client)),
-		"autotask_search_quotes":        makeRunner(searchQuotesHandler(client)),
-		"autotask_create_quote":         makeRunner(createQuoteHandler(client)),
-		"autotask_get_quote_item":       makeRunner(getQuoteItemHandler(client)),
-		"autotask_search_quote_items":   makeRunner(searchQuoteItemsHandler(client)),
-		"autotask_create_quote_item":    makeRunner(createQuoteItemHandler(client)),
-		"autotask_update_quote_item":    makeRunner(updateQuoteItemHandler(client)),
-		"autotask_delete_quote_item":    makeRunner(deleteQuoteItemHandler(client)),
-		"autotask_get_opportunity":      makeRunner(getOpportunityHandler(client)),
-		"autotask_search_opportunities": makeRunner(searchOpportunitiesHandler(client)),
-		"autotask_create_opportunity":   makeRunner(createOpportunityHandler(client)),
-		"autotask_search_invoices":      makeRunner(searchInvoicesHandler(client)),
-		"autotask_search_contracts":     makeRunner(searchContractsHandler(client, mapper)),
+		// Expenses
+		"autotask_get_expense_report":    makeRunner(getExpenseReportHandler(client)),
+		"autotask_search_expense_reports": makeRunner(searchExpenseReportsHandler(client)),
+		"autotask_create_expense_report": makeRunner(createExpenseReportHandler(client)),
+		"autotask_create_expense_item":   makeRunner(createExpenseItemHandler(client)),
 
-		// Products and Services
+		// Sales
 		"autotask_get_product":            makeRunner(getProductHandler(client)),
 		"autotask_search_products":        makeRunner(searchProductsHandler(client)),
 		"autotask_get_service":            makeRunner(getServiceHandler(client)),
@@ -278,11 +278,34 @@ func buildToolDispatcher(client *autotask.Client, mapper *services.MappingCache,
 		"autotask_get_service_bundle":     makeRunner(getServiceBundleHandler(client)),
 		"autotask_search_service_bundles": makeRunner(searchServiceBundlesHandler(client)),
 
-		// Resources
-		"autotask_search_resources": makeRunner(searchResourcesHandler(client)),
+		// Financial
+		"autotask_get_quote":             makeRunner(getQuoteHandler(client)),
+		"autotask_search_quotes":         makeRunner(searchQuotesHandler(client)),
+		"autotask_create_quote":          makeRunner(createQuoteHandler(client)),
+		"autotask_get_quote_item":        makeRunner(getQuoteItemHandler(client)),
+		"autotask_search_quote_items":    makeRunner(searchQuoteItemsHandler(client)),
+		"autotask_create_quote_item":     makeRunner(createQuoteItemHandler(client)),
+		"autotask_update_quote_item":     makeRunner(updateQuoteItemHandler(client)),
+		"autotask_delete_quote_item":     makeRunner(deleteQuoteItemHandler(client)),
+		"autotask_get_opportunity":       makeRunner(getOpportunityHandler(client)),
+		"autotask_search_opportunities":  makeRunner(searchOpportunitiesHandler(client)),
+		"autotask_create_opportunity":    makeRunner(createOpportunityHandler(client)),
+		"autotask_search_contracts":      makeRunner(searchContractsHandler(client, mapper)),
+		"autotask_search_invoices":       makeRunner(searchInvoicesHandler(client)),
+	}
+}
 
-		// Configuration Items
-		"autotask_search_configuration_items": makeRunner(searchConfigurationItemsHandler(client, mapper)),
+// precomputedCategorySummaries is computed once at package initialization.
+var precomputedCategorySummaries map[string]CategorySummary
+
+func init() {
+	precomputedCategorySummaries = make(map[string]CategorySummary, len(ToolCategories))
+	for name, info := range ToolCategories {
+		precomputedCategorySummaries[name] = CategorySummary{
+			Description: info.Description,
+			ToolCount:   len(info.Tools),
+			Tools:       info.Tools,
+		}
 	}
 }
 
@@ -316,34 +339,15 @@ func RegisterLazyTools(s *mcp.Server, client *autotask.Client, mapper *services.
 }
 
 // listCategoriesHandler returns a handler that returns the full category map.
-func listCategoriesHandler() func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoriesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoriesInput) (*mcp.CallToolResult, any, error) {
-		// Build a simplified summary with category name, description, and tool count.
-		type categorySummary struct {
-			Description string   `json:"description"`
-			ToolCount   int      `json:"toolCount"`
-			Tools       []string `json:"tools"`
-		}
-		summary := make(map[string]categorySummary, len(ToolCategories))
-		for name, info := range ToolCategories {
-			summary[name] = categorySummary{
-				Description: info.Description,
-				ToolCount:   len(info.Tools),
-				Tools:       info.Tools,
-			}
-		}
-
-		data, err := json.MarshalIndent(summary, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal categories: %v", err)
-		}
-		return textResult("%s", string(data))
+func listCategoriesHandler() func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoriesInput) (*mcp.CallToolResult, map[string]CategorySummary, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoriesInput) (*mcp.CallToolResult, map[string]CategorySummary, error) {
+		return nil, precomputedCategorySummaries, nil
 	}
 }
 
 // listCategoryToolsHandler returns a handler that lists tools for a given category.
-func listCategoryToolsHandler() func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoryToolsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoryToolsInput) (*mcp.CallToolResult, any, error) {
+func listCategoryToolsHandler() func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoryToolsInput) (*mcp.CallToolResult, CategoryToolsOut, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in ListCategoryToolsInput) (*mcp.CallToolResult, CategoryToolsOut, error) {
 		categoryName := in.Category
 		cat, ok := ToolCategories[in.Category]
 		if !ok {
@@ -359,32 +363,23 @@ func listCategoryToolsHandler() func(ctx context.Context, req *mcp.CallToolReque
 			}
 		}
 		if !ok {
-			return errorResult("unknown category %q; call autotask_list_categories to see available categories", in.Category)
+			return nil, CategoryToolsOut{}, fmt.Errorf("unknown category %q; call autotask_list_categories to see available categories", in.Category)
 		}
 
-		type toolEntry struct {
-			Name        string `json:"name"`
-			Description string `json:"description"`
-		}
-		tools := make([]toolEntry, 0, len(cat.Tools))
+		tools := make([]ToolSummary, 0, len(cat.Tools))
 		for _, name := range cat.Tools {
 			desc := toolDescriptions[name]
 			if desc == "" {
 				desc = name
 			}
-			tools = append(tools, toolEntry{Name: name, Description: desc})
+			tools = append(tools, ToolSummary{Name: name, Description: desc})
 		}
 
-		result := map[string]any{
-			"category":    categoryName,
-			"description": cat.Description,
-			"tools":       tools,
-		}
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal tools: %v", err)
-		}
-		return textResult("%s", string(data))
+		return nil, CategoryToolsOut{
+			Category:    categoryName,
+			Description: cat.Description,
+			Tools:       tools,
+		}, nil
 	}
 }
 
@@ -392,12 +387,12 @@ func listCategoryToolsHandler() func(ctx context.Context, req *mcp.CallToolReque
 func executeToolHandler(dispatcher map[string]ToolRunner) func(ctx context.Context, req *mcp.CallToolRequest, in ExecuteToolInput) (*mcp.CallToolResult, any, error) {
 	return func(ctx context.Context, req *mcp.CallToolRequest, in ExecuteToolInput) (*mcp.CallToolResult, any, error) {
 		if in.ToolName == "" {
-			return errorResult("toolName is required")
+			return nil, nil, fmt.Errorf("toolName is required")
 		}
 
 		runner, ok := dispatcher[in.ToolName]
 		if !ok || runner == nil {
-			return errorResult("unknown tool %q; call autotask_list_categories or autotask_router to discover available tools", in.ToolName)
+			return nil, nil, fmt.Errorf("unknown tool %q; call autotask_list_categories or autotask_router to discover available tools", in.ToolName)
 		}
 
 		return runner(ctx, in.Arguments)
@@ -405,10 +400,10 @@ func executeToolHandler(dispatcher map[string]ToolRunner) func(ctx context.Conte
 }
 
 // routerHandler returns a handler that routes a natural language intent to a tool.
-func routerHandler() func(ctx context.Context, req *mcp.CallToolRequest, in RouterInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in RouterInput) (*mcp.CallToolResult, any, error) {
+func routerHandler() func(ctx context.Context, req *mcp.CallToolRequest, in RouterInput) (*mcp.CallToolResult, RouterOut, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in RouterInput) (*mcp.CallToolResult, RouterOut, error) {
 		if in.Intent == "" {
-			return errorResult("intent is required")
+			return nil, RouterOut{}, fmt.Errorf("intent is required")
 		}
 
 		intentLower := strings.ToLower(in.Intent)
@@ -433,15 +428,10 @@ func routerHandler() func(ctx context.Context, req *mcp.CallToolRequest, in Rout
 			description = "No specific match found. Use autotask_list_categories to browse available tools."
 		}
 
-		result := map[string]any{
-			"intent":        in.Intent,
-			"suggestedTool": suggestedTool,
-			"description":   description,
-		}
-		data, err := json.MarshalIndent(result, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal result: %v", err)
-		}
-		return textResult("%s", string(data))
+		return nil, RouterOut{
+			Intent:        in.Intent,
+			SuggestedTool: suggestedTool,
+			Description:   description,
+		}, nil
 	}
 }

--- a/tools/lazy_test.go
+++ b/tools/lazy_test.go
@@ -2,8 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
-	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -17,39 +15,25 @@ func TestRegisterLazyTools_DoesNotPanic(t *testing.T) {
 	picklist := services.NewPicklistCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "v0.0.1"}, nil)
 
-	// Should not panic.
 	RegisterLazyTools(s, client, mapper, picklist)
 }
 
 func TestListCategories_ReturnsExpectedCategories(t *testing.T) {
-	handler := listCategoriesHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, ListCategoriesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_list_categories",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected at least one content item")
+		t.Fatalf("expected IsError=false, got: %v", result.Content)
 	}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-
-	// Parse the JSON response.
-	var categories map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &categories); err != nil {
-		t.Fatalf("failed to parse response JSON: %v", err)
-	}
-
-	// Check all expected categories are present.
+	categories := parseStructuredContent[map[string]CategorySummary](t, result)
 	expectedCategories := []string{
 		"utility", "companies", "contacts", "tickets", "projects",
 		"time_and_billing", "financial", "products_and_services",
@@ -67,7 +51,6 @@ func TestListCategories_ToolCategoriesMap(t *testing.T) {
 		t.Fatal("ToolCategories should not be empty")
 	}
 
-	// Verify tickets category has expected tools.
 	ticketsCat, ok := ToolCategories["tickets"]
 	if !ok {
 		t.Fatal("expected tickets category")
@@ -75,7 +58,6 @@ func TestListCategories_ToolCategoriesMap(t *testing.T) {
 	if len(ticketsCat.Tools) == 0 {
 		t.Error("tickets category should have tools")
 	}
-	// Check that autotask_search_tickets is in there.
 	found := false
 	for _, tool := range ticketsCat.Tools {
 		if tool == "autotask_search_tickets" {
@@ -89,41 +71,43 @@ func TestListCategories_ToolCategoriesMap(t *testing.T) {
 }
 
 func TestListCategoryTools_KnownCategory(t *testing.T) {
-	handler := listCategoryToolsHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, ListCategoryToolsInput{Category: "tickets"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_list_category_tools",
+		Arguments: map[string]any{
+			"category": "tickets",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
-		t.Fatal("expected successful result")
-	}
-
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
+	if result.IsError {
+		t.Fatalf("expected successful result, got: %v", result)
 	}
 
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
+	resp := parseStructuredContent[CategoryToolsOut](t, result)
+	if resp.Category != "tickets" {
+		t.Errorf("expected category=tickets, got %v", resp.Category)
 	}
-
-	if resp["category"] != "tickets" {
-		t.Errorf("expected category=tickets, got %v", resp["category"])
-	}
-	tools, ok := resp["tools"].([]any)
-	if !ok || len(tools) == 0 {
+	if len(resp.Tools) == 0 {
 		t.Error("expected non-empty tools array")
 	}
 }
 
 func TestListCategoryTools_UnknownCategory(t *testing.T) {
-	handler := listCategoryToolsHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, ListCategoryToolsInput{Category: "nonexistent_category_xyz"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_list_category_tools",
+		Arguments: map[string]any{
+			"category": "nonexistent_category_xyz",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for unknown category")
@@ -132,68 +116,59 @@ func TestListCategoryTools_UnknownCategory(t *testing.T) {
 
 func TestExecuteTool_DispatchesRealTool(t *testing.T) {
 	ticket := autotasktest.TicketFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-	mapper := services.NewMappingCache(client)
-	picklist := services.NewPicklistCache(client)
-	dispatcher := buildToolDispatcher(client, mapper, picklist)
+	cs, _ := setupLazyWireTest(t, autotasktest.WithEntity(ticket))
+	ctx := context.Background()
 
-	handler := executeToolHandler(dispatcher)
-
-	result, _, err := handler(context.Background(), nil, ExecuteToolInput{
-		ToolName:  "autotask_search_tickets",
-		Arguments: map[string]any{"maxResults": 10},
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_execute_tool",
+		Arguments: map[string]any{
+			"toolName":  "autotask_search_tickets",
+			"arguments": map[string]any{"maxResults": 10},
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
+	if result.IsError {
 		t.Fatalf("expected successful execution result, got: %v", result)
 	}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(textContent.Text, "items") && !strings.Contains(textContent.Text, "ticketNumber") {
-		t.Errorf("expected executed tool result to return ticket data, got: %s", textContent.Text)
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned ticket, got %d", resp.Summary.Returned)
 	}
 }
 
 func TestExecuteTool_UnknownTool(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := services.NewMappingCache(client)
-	picklist := services.NewPicklistCache(client)
-	dispatcher := buildToolDispatcher(client, mapper, picklist)
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	handler := executeToolHandler(dispatcher)
-
-	result, _, err := handler(context.Background(), nil, ExecuteToolInput{
-		ToolName: "nonexistent_tool_name",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_execute_tool",
+		Arguments: map[string]any{
+			"toolName": "nonexistent_tool_name",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
-	if result == nil || !result.IsError {
+	if !result.IsError {
 		t.Fatal("expected IsError=true for unknown tool")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected at least one content item")
-	}
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-	if !strings.Contains(textContent.Text, "unknown tool") {
-		t.Errorf("expected error message to mention unknown tool, got: %s", textContent.Text)
 	}
 }
 
 func TestExecuteTool_EmptyToolName(t *testing.T) {
-	handler := executeToolHandler(nil)
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, ExecuteToolInput{ToolName: ""})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_execute_tool",
+		Arguments: map[string]any{
+			"toolName": "",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for empty toolName")
@@ -206,17 +181,24 @@ func TestDispatcher_AllCategoryToolsCovered(t *testing.T) {
 	picklist := services.NewPicklistCache(client)
 	dispatcher := buildToolDispatcher(client, mapper, picklist)
 
+	toolCount := 0
 	for catName, cat := range ToolCategories {
+		toolCount += len(cat.Tools)
 		for _, toolName := range cat.Tools {
 			if _, ok := dispatcher[toolName]; !ok {
 				t.Errorf("tool %q in category %q is not covered by dispatcher", toolName, catName)
 			}
 		}
 	}
+
+	if len(dispatcher) != toolCount {
+		t.Errorf("dispatcher has %d tools, but ToolCategories defines %d", len(dispatcher), toolCount)
+	}
 }
 
 func TestRouter_MatchesKeywords(t *testing.T) {
-	handler := routerHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
 	tests := []struct {
 		intent      string
@@ -230,37 +212,39 @@ func TestRouter_MatchesKeywords(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.intent, func(t *testing.T) {
-			result, _, err := handler(context.Background(), nil, RouterInput{Intent: tt.intent})
+			result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+				Name: "autotask_router",
+				Arguments: map[string]any{
+					"intent": tt.intent,
+				},
+			})
 			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+				t.Fatalf("unexpected wire error: %v", err)
 			}
-			if result == nil || result.IsError {
-				t.Fatal("expected successful result")
-			}
-
-			textContent, ok := result.Content[0].(*mcp.TextContent)
-			if !ok {
-				t.Fatal("expected TextContent")
+			if result.IsError {
+				t.Fatalf("expected successful result, got: %v", result)
 			}
 
-			var resp map[string]any
-			if err := json.Unmarshal([]byte(textContent.Text), &resp); err != nil {
-				t.Fatalf("failed to parse response: %v", err)
-			}
-
-			if resp["suggestedTool"] != tt.expectsTool {
-				t.Errorf("intent %q: expected suggestedTool=%q, got %q", tt.intent, tt.expectsTool, resp["suggestedTool"])
+			resp := parseStructuredContent[RouterOut](t, result)
+			if resp.SuggestedTool != tt.expectsTool {
+				t.Errorf("intent %q: expected suggestedTool=%q, got %q", tt.intent, tt.expectsTool, resp.SuggestedTool)
 			}
 		})
 	}
 }
 
 func TestRouter_EmptyIntent(t *testing.T) {
-	handler := routerHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, RouterInput{Intent: ""})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_router",
+		Arguments: map[string]any{
+			"intent": "",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for empty intent")
@@ -269,9 +253,7 @@ func TestRouter_EmptyIntent(t *testing.T) {
 
 // TestToolCategories_AllToolsHaveDescriptions ensures every tool listed in
 // ToolCategories has a corresponding entry in toolDescriptions, and vice versa.
-// This prevents drift when tools are added to RegisterAll but not to lazy.go.
 func TestToolCategories_AllToolsHaveDescriptions(t *testing.T) {
-	// Collect all tool names from ToolCategories.
 	categoryTools := map[string]bool{}
 	for _, cat := range ToolCategories {
 		for _, tool := range cat.Tools {
@@ -279,14 +261,12 @@ func TestToolCategories_AllToolsHaveDescriptions(t *testing.T) {
 		}
 	}
 
-	// Every tool in ToolCategories must have a description.
 	for tool := range categoryTools {
 		if _, ok := toolDescriptions[tool]; !ok {
 			t.Errorf("tool %q is in ToolCategories but missing from toolDescriptions", tool)
 		}
 	}
 
-	// Every tool in toolDescriptions must be in some category.
 	for tool := range toolDescriptions {
 		if !categoryTools[tool] {
 			t.Errorf("tool %q is in toolDescriptions but not in any ToolCategories category", tool)
@@ -296,7 +276,7 @@ func TestToolCategories_AllToolsHaveDescriptions(t *testing.T) {
 
 // TestToolCategories_NoDuplicates ensures no tool appears in multiple categories.
 func TestToolCategories_NoDuplicates(t *testing.T) {
-	seen := map[string]string{} // tool → category
+	seen := map[string]string{}
 	for catName, cat := range ToolCategories {
 		for _, tool := range cat.Tools {
 			if prevCat, ok := seen[tool]; ok {
@@ -308,27 +288,25 @@ func TestToolCategories_NoDuplicates(t *testing.T) {
 }
 
 func TestRouter_FallbackToListCategories(t *testing.T) {
-	handler := routerHandler()
+	cs, _ := setupLazyWireTest(t)
+	ctx := context.Background()
 
-	result, _, err := handler(context.Background(), nil, RouterInput{Intent: "xyzzy something completely unknown"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_router",
+		Arguments: map[string]any{
+			"intent": "xyzzy something completely unknown",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
-		t.Fatal("expected successful result")
-	}
-
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
+	if result.IsError {
+		t.Fatalf("expected successful result, got: %v", result)
 	}
 
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &resp); err != nil {
-		t.Fatalf("failed to parse response: %v", err)
-	}
-
-	if resp["suggestedTool"] != "autotask_list_categories" {
-		t.Errorf("expected fallback to autotask_list_categories, got %v", resp["suggestedTool"])
+	resp := parseStructuredContent[RouterOut](t, result)
+	if resp.SuggestedTool != "autotask_list_categories" {
+		t.Errorf("expected fallback to autotask_list_categories, got %v", resp.SuggestedTool)
 	}
 }
+

--- a/tools/notes.go
+++ b/tools/notes.go
@@ -2,7 +2,8 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"errors"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -72,11 +73,21 @@ const maxNoteSummaryLength = 500
 
 func truncateNoteBody(m map[string]any) {
 	for _, field := range []string{"description", "note"} {
-		if val, ok := m[field].(string); ok {
-			runes := []rune(val)
-			if len(runes) > maxNoteSummaryLength {
-				m[field] = string(runes[:maxNoteSummaryLength]) + "\n... [truncated for search, use get note tool for full text]"
+		val, ok := m[field].(string)
+		if !ok || len(val) <= maxNoteSummaryLength {
+			continue
+		}
+		count := 0
+		byteIdx := len(val)
+		for i := range val {
+			if count == maxNoteSummaryLength {
+				byteIdx = i
+				break
 			}
+			count++
+		}
+		if byteIdx < len(val) {
+			m[field] = val[:byteIdx] + "\n... [truncated for search, use get note tool for full text]"
 		}
 	}
 }
@@ -91,31 +102,31 @@ func RegisterNoteTools(s *mcp.Server, client *autotask.Client) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_search_ticket_notes",
-		Description: "List notes attached to one service ticket by ticketId, returning up to maxResults note records (default 25, max 100) with bodies bounded to prevent context explosion. Read-only.",
+		Description: "List note headers and truncated bodies (first 500 characters) for a ticket, returning a compact summary capped at maxResults (default 25, max 100). Use this to scan a ticket history; use autotask_get_ticket_note for full text. Requires ticketId. Read-only.",
 		Annotations: readOnlyTool("Search ticket notes"),
 	}, searchTicketNotesHandler(client))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_create_ticket_note",
-		Description: "Add a note to a service ticket from a description body, with optional title, note type, and publish scope that controls internal versus client visibility. Requires ticketId and description; returns the created note including its new ID. To read existing ticket notes use autotask_search_ticket_notes or autotask_get_ticket_note instead. Writes to Autotask.",
+		Description: "Add a note to an existing ticket from a title and description, with optional noteType and publish scope. Requires ticketId and description. Writes to Autotask.",
 		Annotations: createTool("Create ticket note"),
 	}, createTicketNoteHandler(client))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_get_project_note",
-		Description: "Retrieve one project note by its numeric note ID, returning the complete note title, body, and type recorded against a project. Read-only.",
+		Description: "Retrieve one project note by its numeric note ID, returning the complete note title, description, and type recorded against a project. Read-only.",
 		Annotations: readOnlyTool("Get project note"),
 	}, getProjectNoteHandler(client))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_search_project_notes",
-		Description: "List notes attached to one project by projectId, returning up to maxResults note records (default 25, max 100) with bodies bounded to prevent context explosion. Read-only.",
+		Description: "List note headers and truncated descriptions (first 500 characters) for a project, returning a compact summary capped at maxResults (default 25, max 100). Use autotask_get_project_note for full text. Requires projectId. Read-only.",
 		Annotations: readOnlyTool("Search project notes"),
 	}, searchProjectNotesHandler(client))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_create_project_note",
-		Description: "Add a note to a project from a description body, with optional title and note type. Requires projectId and description; returns the created note including its new ID. To read existing project notes use autotask_search_project_notes or autotask_get_project_note instead. Writes to Autotask.",
+		Description: "Add a note to an existing project from a description and optional title and noteType. Requires projectId and description. Writes to Autotask.",
 		Annotations: createTool("Create project note"),
 	}, createProjectNoteHandler(client))
 
@@ -127,59 +138,59 @@ func RegisterNoteTools(s *mcp.Server, client *autotask.Client) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_search_company_notes",
-		Description: "List notes attached to one company account by companyId, returning up to maxResults note records (default 25, max 100) with bodies bounded to prevent context explosion. Read-only.",
+		Description: "List note headers and truncated bodies (first 500 characters) for a company, returning a compact summary capped at maxResults (default 25, max 100). Use autotask_get_company_note for full text. Requires companyId. Read-only.",
 		Annotations: readOnlyTool("Search company notes"),
 	}, searchCompanyNotesHandler(client))
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "autotask_create_company_note",
-		Description: "Add a note to a company account from a description body, with optional title and action type. Requires companyId and description; returns the created note including its new ID. To read existing company notes use autotask_search_company_notes or autotask_get_company_note instead. Writes to Autotask.",
+		Description: "Add a note to an existing company account from a description (body) and optional title (name) and actionType. Requires companyId and description. Writes to Autotask.",
 		Annotations: createTool("Create company note"),
 	}, createCompanyNoteHandler(client))
 }
 
 // getTicketNoteHandler returns a handler that retrieves a single ticket note by ID.
-func getTicketNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketNoteInput) (*mcp.CallToolResult, any, error) {
+func getTicketNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		note, err := autotask.Get[entities.TicketNote](ctx, client, in.NoteID)
 		if err != nil {
-			return errorResult("failed to get ticket note %d: %v", in.NoteID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(note)
 		if err != nil {
-			return errorResult("failed to convert ticket note: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket note: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchTicketNotesHandler returns a handler that lists notes for a ticket.
-func searchTicketNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketNotesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketNotesInput) (*mcp.CallToolResult, any, error) {
+func searchTicketNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		notes, err := autotask.ListChild[entities.Ticket, entities.TicketNote](ctx, client, in.TicketID)
 		if err != nil {
-			return errorResult("failed to list ticket notes for ticket %d: %v", in.TicketID, err)
+			var notFound *autotask.NotFoundError
+			if errors.As(err, &notFound) {
+				return emptySearchResult()
+			}
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(notes) == 0 {
-			return textResult("No ticket notes found")
+			return emptySearchResult()
 		}
 
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
+		hasMore := len(notes) >= maxResults && maxResults > 0
 		if len(notes) > maxResults {
 			notes = notes[:maxResults]
 		}
 
 		maps, err := entitiesToMaps(notes)
 		if err != nil {
-			return errorResult("failed to convert ticket notes: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		for _, m := range maps {
@@ -187,20 +198,28 @@ func searchTicketNotesHandler(client *autotask.Client) func(ctx context.Context,
 			services.FrameUntrustedMapFields(m)
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket notes: %v", err)
+		hint := ""
+		if hasMore {
+			hint = "Maximum result limit reached. Use narrower search filters to find specific records."
 		}
 
-		return textResult("%s", string(data))
+		return nil, services.CompactResponse{
+			Summary: services.CompactSummary{
+				Returned:   len(maps),
+				HasMore:    hasMore,
+				MaxResults: maxResults,
+				Hint:       hint,
+			},
+			Items: maps,
+		}, nil
 	}
 }
 
 // createTicketNoteHandler returns a handler that creates a new note on a ticket.
-func createTicketNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketNoteInput) (*mcp.CallToolResult, any, error) {
+func createTicketNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		if in.Description == "" {
-			return errorResult("description is required")
+			return nil, nil, fmt.Errorf("description is required")
 		}
 		note := &entities.TicketNote{
 			Description: autotask.Set(in.Description),
@@ -218,58 +237,53 @@ func createTicketNoteHandler(client *autotask.Client) func(ctx context.Context, 
 
 		created, err := autotask.CreateChild[entities.Ticket, entities.TicketNote](ctx, client, in.TicketID, note)
 		if err != nil {
-			return errorResult("failed to create ticket note: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created ticket note: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created ticket note: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // getProjectNoteHandler returns a handler that retrieves a single project note by ID.
-func getProjectNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetProjectNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetProjectNoteInput) (*mcp.CallToolResult, any, error) {
+func getProjectNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetProjectNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetProjectNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		note, err := autotask.Get[entities.ProjectNote](ctx, client, in.NoteID)
 		if err != nil {
-			return errorResult("failed to get project note %d: %v", in.NoteID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(note)
 		if err != nil {
-			return errorResult("failed to convert project note: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal project note: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchProjectNotesHandler returns a handler that lists notes for a project.
-func searchProjectNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectNotesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectNotesInput) (*mcp.CallToolResult, any, error) {
+func searchProjectNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		notes, err := autotask.ListChildRaw(ctx, client, "Projects", in.ProjectID, "ProjectNotes")
 		if err != nil {
-			return errorResult("failed to list project notes for project %d: %v", in.ProjectID, err)
+			var notFound *autotask.NotFoundError
+			if errors.As(err, &notFound) {
+				return emptySearchResult()
+			}
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(notes) == 0 {
-			return textResult("No project notes found")
+			return emptySearchResult()
 		}
 
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
+		hasMore := len(notes) >= maxResults && maxResults > 0
 		if len(notes) > maxResults {
 			notes = notes[:maxResults]
 		}
@@ -279,20 +293,28 @@ func searchProjectNotesHandler(client *autotask.Client) func(ctx context.Context
 			services.FrameUntrustedMapFields(m)
 		}
 
-		data, err := json.MarshalIndent(notes, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal project notes: %v", err)
+		hint := ""
+		if hasMore {
+			hint = "Maximum result limit reached. Use narrower search filters to find specific records."
 		}
 
-		return textResult("%s", string(data))
+		return nil, services.CompactResponse{
+			Summary: services.CompactSummary{
+				Returned:   len(notes),
+				HasMore:    hasMore,
+				MaxResults: maxResults,
+				Hint:       hint,
+			},
+			Items: notes,
+		}, nil
 	}
 }
 
 // createProjectNoteHandler returns a handler that creates a new note on a project.
-func createProjectNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectNoteInput) (*mcp.CallToolResult, any, error) {
+func createProjectNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		if in.Description == "" {
-			return errorResult("description is required")
+			return nil, nil, fmt.Errorf("description is required")
 		}
 		note := &entities.ProjectNote{
 			Description: autotask.Set(in.Description),
@@ -306,57 +328,53 @@ func createProjectNoteHandler(client *autotask.Client) func(ctx context.Context,
 
 		created, err := autotask.CreateChild[entities.Project, entities.ProjectNote](ctx, client, in.ProjectID, note)
 		if err != nil {
-			return errorResult("failed to create project note: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created project note: %v", err)
-		}
-		out, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created project note: %v", err)
+			return nil, nil, err
 		}
 
-		return textResult("%s", string(out))
+		return nil, m, nil
 	}
 }
 
 // getCompanyNoteHandler returns a handler that retrieves a single company note by ID.
-func getCompanyNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetCompanyNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetCompanyNoteInput) (*mcp.CallToolResult, any, error) {
+func getCompanyNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetCompanyNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetCompanyNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		note, err := autotask.Get[entities.CompanyNote](ctx, client, in.NoteID)
 		if err != nil {
-			return errorResult("failed to get company note %d: %v", in.NoteID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(note)
 		if err != nil {
-			return errorResult("failed to convert company note: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal company note: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchCompanyNotesHandler returns a handler that lists notes for a company.
-func searchCompanyNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompanyNotesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompanyNotesInput) (*mcp.CallToolResult, any, error) {
+func searchCompanyNotesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompanyNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchCompanyNotesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		notes, err := autotask.ListChildRaw(ctx, client, "Companies", in.CompanyID, "CompanyNotes")
 		if err != nil {
-			return errorResult("failed to list company notes for company %d: %v", in.CompanyID, err)
+			var notFound *autotask.NotFoundError
+			if errors.As(err, &notFound) {
+				return emptySearchResult()
+			}
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(notes) == 0 {
-			return textResult("No company notes found")
+			return emptySearchResult()
 		}
 
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
+		hasMore := len(notes) >= maxResults && maxResults > 0
 		if len(notes) > maxResults {
 			notes = notes[:maxResults]
 		}
@@ -366,24 +384,32 @@ func searchCompanyNotesHandler(client *autotask.Client) func(ctx context.Context
 			services.FrameUntrustedMapFields(m)
 		}
 
-		data, err := json.MarshalIndent(notes, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal company notes: %v", err)
+		hint := ""
+		if hasMore {
+			hint = "Maximum result limit reached. Use narrower search filters to find specific records."
 		}
 
-		return textResult("%s", string(data))
+		return nil, services.CompactResponse{
+			Summary: services.CompactSummary{
+				Returned:   len(notes),
+				HasMore:    hasMore,
+				MaxResults: maxResults,
+				Hint:       hint,
+			},
+			Items: notes,
+		}, nil
 	}
 }
 
 // createCompanyNoteHandler returns a handler that creates a new note on a company.
-func createCompanyNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyNoteInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyNoteInput) (*mcp.CallToolResult, any, error) {
+func createCompanyNoteHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyNoteInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateCompanyNoteInput) (*mcp.CallToolResult, map[string]any, error) {
 		if in.Description == "" {
-			return errorResult("description is required")
+			return nil, nil, fmt.Errorf("description is required")
 		}
 		// CompanyNote uses different field names than TicketNote/ProjectNote:
-		// Input.Description → entity.Note (body text)
-		// Input.Title → entity.Name (display name)
+		// Input.Description -> entity.Note (body text)
+		// Input.Title -> entity.Name (display name)
 		note := &entities.CompanyNote{
 			Note: autotask.Set(in.Description),
 		}
@@ -396,18 +422,14 @@ func createCompanyNoteHandler(client *autotask.Client) func(ctx context.Context,
 
 		created, err := autotask.CreateChild[entities.Company, entities.CompanyNote](ctx, client, in.CompanyID, note)
 		if err != nil {
-			return errorResult("failed to create company note: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created company note: %v", err)
-		}
-		out, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created company note: %v", err)
+			return nil, nil, err
 		}
 
-		return textResult("%s", string(out))
+		return nil, m, nil
 	}
 }

--- a/tools/notes_test.go
+++ b/tools/notes_test.go
@@ -2,11 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/go-autotask/entities"
@@ -19,81 +19,90 @@ func TestRegisterNoteTools_NoPanic(t *testing.T) {
 	RegisterNoteTools(s, client)
 }
 
-// TestSearchTicketNotesHandler_NoNotes tests that the handler returns a result (possibly empty
-// or error) without panicking when called on an empty server.
+// TestSearchTicketNotesHandler_NoNotes tests searching ticket notes on an empty server.
 func TestSearchTicketNotesHandler_NoNotes(t *testing.T) {
-	// The mock server returns 404 when the TicketNotes entity store does not exist,
-	// which propagates as an error result (not a protocol error). Verify no panic.
-	_, client := autotasktest.NewServer(t)
-	handler := searchTicketNotesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTicketNotesInput{TicketID: 3001})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_ticket_notes",
+		Arguments: map[string]any{
+			"ticketId": 3001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	// The result may be an error (404 from mock) or success; both are acceptable.
-	// We only verify there is no panic and a result is returned.
-}
-
-// TestSearchTicketNotesHandler_WithNotes tests that seeded notes are returned.
-func TestSearchTicketNotesHandler_WithNotes(t *testing.T) {
-	note := autotasktest.TicketNoteFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(note))
-
-	handler := searchTicketNotesHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchTicketNotesInput{TicketID: 3001})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		if len(result.Content) > 0 {
+			if tc, ok := result.Content[0].(*mcp.TextContent); ok {
+				t.Fatalf("expected non-error result, got IsError=true; content: %s", tc.Text)
+			}
+		}
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned notes, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestSearchTicketNotesHandler_TruncationAndFraming tests that long note bodies are truncated and untrusted content is framed.
+// TestSearchTicketNotesHandler_WithNotes tests that seeded notes are returned over wire.
+func TestSearchTicketNotesHandler_WithNotes(t *testing.T) {
+	note := autotasktest.TicketNoteFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(note))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_ticket_notes",
+		Arguments: map[string]any{
+			"ticketId": 3001,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 note, got %d", resp.Summary.Returned)
+	}
+}
+
+// TestSearchTicketNotesHandler_TruncationAndFraming tests that long note bodies are truncated and untrusted content is framed over wire.
 func TestSearchTicketNotesHandler_TruncationAndFraming(t *testing.T) {
 	longDescription := strings.Repeat("A", 600)
 	note := autotasktest.TicketNoteFixture(func(n *entities.TicketNote) {
 		n.Description = autotask.Set(longDescription)
 		n.Title = autotask.Set("Untrusted Note Title")
 	})
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(note))
-
-	handler := searchTicketNotesHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(note))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTicketNotesInput{TicketID: 3001, MaxResults: 10})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_ticket_notes",
+		Arguments: map[string]any{
+			"ticketId":   3001,
+			"maxResults": 10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil || result.IsError {
+	if result.IsError {
 		t.Fatalf("expected non-error result, got: %v", result)
 	}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
-	}
-
-	var notes []map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &notes); err != nil {
-		t.Fatalf("unmarshal error: %v", err)
-	}
-
-	if len(notes) == 0 {
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if len(resp.Items) == 0 {
 		t.Fatal("expected at least 1 note")
 	}
 
-	n := notes[0]
+	n := resp.Items[0]
 	desc, _ := n["description"].(string)
 	if !strings.Contains(desc, "truncated for search") {
 		t.Errorf("expected description to be truncated, got: %v", desc)
@@ -108,176 +117,217 @@ func TestSearchTicketNotesHandler_TruncationAndFraming(t *testing.T) {
 	}
 }
 
-// TestGetTicketNoteHandler_NotFound tests that a missing note returns an error result.
+// TestGetTicketNoteHandler_NotFound tests that a missing note returns an error result over wire.
 func TestGetTicketNoteHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getTicketNoteHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketNoteInput{NoteID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_note",
+		Arguments: map[string]any{
+			"noteId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing note")
 	}
 }
 
-// TestGetTicketNoteHandler_Success tests that a seeded note is retrieved.
+// TestGetTicketNoteHandler_Success tests that a seeded note is retrieved over wire.
 func TestGetTicketNoteHandler_Success(t *testing.T) {
 	note := autotasktest.TicketNoteFixture()
 	noteID, ok := note.ID.Get()
 	if !ok {
 		t.Fatal("fixture note has no ID")
 	}
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(note))
-
-	handler := getTicketNoteHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(note))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketNoteInput{NoteID: noteID})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-}
-
-// TestCreateTicketNoteHandler_Success tests that a ticket note can be created.
-func TestCreateTicketNoteHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.TicketNoteFixture()),
-	)
-
-	handler := createTicketNoteHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, CreateTicketNoteInput{
-		TicketID:    3001,
-		Description: "Test note description",
-		Title:       "Test note",
-		NoteType:    1,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_note",
+		Arguments: map[string]any{
+			"noteId": noteID,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	idVal, ok := m["id"]
+	if !ok {
+		t.Fatalf("expected 'id' field in note response")
+	}
+	fVal, isFloat := idVal.(float64)
+	if !isFloat || int64(fVal) != noteID {
+		t.Errorf("expected id=%d, got %v", noteID, idVal)
 	}
 }
 
-// TestGetProjectNoteHandler_NotFound tests that a missing project note returns an error result.
-func TestGetProjectNoteHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getProjectNoteHandler(client)
+// TestCreateTicketNoteHandler_Success tests creating a ticket note over wire.
+func TestCreateTicketNoteHandler_Success(t *testing.T) {
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.TicketNoteFixture()))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetProjectNoteInput{NoteID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_ticket_note",
+		Arguments: map[string]any{
+			"ticketId":    3001,
+			"description": "Test note description",
+			"title":       "Test note",
+			"noteType":    1,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "Test note") {
+		t.Errorf("expected title to contain 'Test note', got %v", m["title"])
+	}
+}
+
+// TestGetProjectNoteHandler_NotFound tests that a missing project note returns an error result over wire.
+func TestGetProjectNoteHandler_NotFound(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_project_note",
+		Arguments: map[string]any{
+			"noteId": 99999,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing project note")
 	}
 }
 
-// TestSearchProjectNotesHandler_NoNotes tests that the handler does not panic on an empty server.
+// TestSearchProjectNotesHandler_NoNotes tests searching project notes on an empty server.
 func TestSearchProjectNotesHandler_NoNotes(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchProjectNotesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchProjectNotesInput{ProjectID: 4001})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_project_notes",
+		Arguments: map[string]any{
+			"projectId": 4001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned project notes, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestSearchCompanyNotesHandler_NoNotes tests that the handler does not panic on an empty server.
+// TestSearchCompanyNotesHandler_NoNotes tests searching company notes on an empty server.
 func TestSearchCompanyNotesHandler_NoNotes(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchCompanyNotesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchCompanyNotesInput{CompanyID: 1001})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_company_notes",
+		Arguments: map[string]any{
+			"companyId": 1001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned company notes, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestCreateProjectNoteHandler_Success tests that a project note can be created.
+// TestCreateProjectNoteHandler_Success tests creating a project note over wire.
 func TestCreateProjectNoteHandler_Success(t *testing.T) {
 	proj := autotasktest.ProjectFixture()
 	projID, ok := proj.ID.Get()
 	if !ok {
 		t.Fatal("fixture project has no ID")
 	}
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(proj))
-
-	handler := createProjectNoteHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(proj))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateProjectNoteInput{
-		ProjectID:   projID,
-		Description: "Project note body",
-		Title:       "Project note title",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_project_note",
+		Arguments: map[string]any{
+			"projectId":   projID,
+			"description": "Project note body",
+			"title":       "Project note title",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "Project note title") {
+		t.Errorf("expected title to contain 'Project note title', got %v", m["title"])
 	}
 }
 
-// TestCreateCompanyNoteHandler_Success tests that a company note can be created.
+// TestCreateCompanyNoteHandler_Success tests creating a company note over wire.
 func TestCreateCompanyNoteHandler_Success(t *testing.T) {
 	comp := autotasktest.CompanyFixture()
 	compID, ok := comp.ID.Get()
 	if !ok {
 		t.Fatal("fixture company has no ID")
 	}
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(comp))
-
-	handler := createCompanyNoteHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(comp))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, CreateCompanyNoteInput{
-		CompanyID:   compID,
-		Description: "Company note body",
-		Title:       "Company note title",
-		ActionType:  1,
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_company_note",
+		Arguments: map[string]any{
+			"companyId":   compID,
+			"description": "Company note body",
+			"title":       "Company note title",
+			"actionType":  1,
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+		t.Fatalf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["name"].(string)
+	if !strings.Contains(nameStr, "Company note title") {
+		t.Errorf("expected name to contain 'Company note title', got %v", m["name"])
 	}
 }
+
 

--- a/tools/picklists.go
+++ b/tools/picklists.go
@@ -2,11 +2,12 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"fmt"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
+	"github.com/tphakala/go-autotask/metadata"
 )
 
 // GetFieldInfoInput defines the input parameters for getting field info.
@@ -43,53 +44,47 @@ func RegisterPicklistTools(s *mcp.Server, client *autotask.Client, picklist *ser
 }
 
 // listQueuesHandler returns a handler that lists all queue picklist values.
-func listQueuesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func listQueuesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
 		values, err := picklist.GetPicklistValues(ctx, "Tickets", "queueID")
 		if err != nil {
-			return errorResult("failed to get queue picklist values: %v", err)
+			return nil, nil, err
+		}
+		if values == nil {
+			values = []metadata.PickListValue{}
 		}
 
-		data, err := json.MarshalIndent(values, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal queue values: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, values, nil
 	}
 }
 
 // listTicketStatusesHandler returns a handler that lists all ticket status picklist values.
-func listTicketStatusesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func listTicketStatusesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
 		values, err := picklist.GetPicklistValues(ctx, "Tickets", "status")
 		if err != nil {
-			return errorResult("failed to get ticket status picklist values: %v", err)
+			return nil, nil, err
+		}
+		if values == nil {
+			values = []metadata.PickListValue{}
 		}
 
-		data, err := json.MarshalIndent(values, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket status values: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, values, nil
 	}
 }
 
 // listTicketPrioritiesHandler returns a handler that lists all ticket priority picklist values.
-func listTicketPrioritiesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, any, error) {
+func listTicketPrioritiesHandler(picklist *services.PicklistCache) func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in struct{}) (*mcp.CallToolResult, []metadata.PickListValue, error) {
 		values, err := picklist.GetPicklistValues(ctx, "Tickets", "priority")
 		if err != nil {
-			return errorResult("failed to get ticket priority picklist values: %v", err)
+			return nil, nil, err
+		}
+		if values == nil {
+			values = []metadata.PickListValue{}
 		}
 
-		data, err := json.MarshalIndent(values, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket priority values: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, values, nil
 	}
 }
 
@@ -98,28 +93,19 @@ func getFieldInfoHandler(picklist *services.PicklistCache) func(ctx context.Cont
 	return func(ctx context.Context, req *mcp.CallToolRequest, in GetFieldInfoInput) (*mcp.CallToolResult, any, error) {
 		fields, err := picklist.GetFields(ctx, in.EntityType)
 		if err != nil {
-			return errorResult("failed to get fields for entity %q: %v", in.EntityType, err)
+			return nil, nil, err
 		}
 
 		// Filter to a specific field if requested.
 		if in.FieldName != "" {
 			for _, f := range fields {
 				if f.Name == in.FieldName {
-					data, err := json.MarshalIndent(f, "", "  ")
-					if err != nil {
-						return errorResult("failed to marshal field info: %v", err)
-					}
-					return textResult("%s", string(data))
+					return nil, f, nil
 				}
 			}
-			return textResult("Field %q not found on entity %q", in.FieldName, in.EntityType)
+			return nil, nil, fmt.Errorf("field %q not found on entity %q", in.FieldName, in.EntityType)
 		}
 
-		data, err := json.MarshalIndent(fields, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal fields: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, fields, nil
 	}
 }

--- a/tools/picklists_test.go
+++ b/tools/picklists_test.go
@@ -5,27 +5,22 @@ import (
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	autotask "github.com/tphakala/go-autotask"
-	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/autotask-mcp/services"
+	"github.com/tphakala/go-autotask/autotasktest"
+	"github.com/tphakala/go-autotask/metadata"
 )
-
-// newTestPicklist creates a PicklistCache backed by the provided client.
-func newTestPicklist(client *autotask.Client) *services.PicklistCache {
-	return services.NewPicklistCache(client)
-}
 
 // TestRegisterPicklistTools_NoPanic verifies registration does not panic.
 func TestRegisterPicklistTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	picklist := newTestPicklist(client)
+	picklist := services.NewPicklistCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 	RegisterPicklistTools(s, client, picklist)
 }
 
-// TestListQueuesHandler_ReturnsResult tests that the handler returns a result without panicking.
+// TestListQueuesHandler_ReturnsResult tests that list_queues returns structured list over wire.
 func TestListQueuesHandler_ReturnsResult(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Tickets",
 			autotasktest.EntityInfoResponse{Name: "Tickets", CanCreate: true, CanQuery: true},
@@ -35,25 +30,26 @@ func TestListQueuesHandler_ReturnsResult(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := listQueuesHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, struct{}{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_list_queues",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false")
+		t.Fatalf("expected IsError=false; content: %v", result.Content)
 	}
+
+	values := parseStructuredContent[[]metadata.PickListValue](t, result)
+	_ = values
 }
 
-// TestListTicketStatusesHandler_ReturnsResult tests that the handler returns a result.
+// TestListTicketStatusesHandler_ReturnsResult tests that list_ticket_statuses returns structured list over wire.
 func TestListTicketStatusesHandler_ReturnsResult(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Tickets",
 			autotasktest.EntityInfoResponse{Name: "Tickets", CanCreate: true, CanQuery: true},
@@ -63,25 +59,26 @@ func TestListTicketStatusesHandler_ReturnsResult(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := listTicketStatusesHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, struct{}{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_list_ticket_statuses",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false")
+		t.Fatalf("expected IsError=false; content: %v", result.Content)
 	}
+
+	values := parseStructuredContent[[]metadata.PickListValue](t, result)
+	_ = values
 }
 
-// TestListTicketPrioritiesHandler_ReturnsResult tests that the handler returns a result.
+// TestListTicketPrioritiesHandler_ReturnsResult tests that list_ticket_priorities returns structured list over wire.
 func TestListTicketPrioritiesHandler_ReturnsResult(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Tickets",
 			autotasktest.EntityInfoResponse{Name: "Tickets", CanCreate: true, CanQuery: true},
@@ -91,25 +88,26 @@ func TestListTicketPrioritiesHandler_ReturnsResult(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := listTicketPrioritiesHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, struct{}{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_list_ticket_priorities",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Error("expected IsError=false")
+		t.Fatalf("expected IsError=false; content: %v", result.Content)
 	}
+
+	values := parseStructuredContent[[]metadata.PickListValue](t, result)
+	_ = values
 }
 
-// TestGetFieldInfoHandler_AllFields tests that all fields for an entity are returned.
+// TestGetFieldInfoHandler_AllFields tests that all fields for an entity are returned over wire.
 func TestGetFieldInfoHandler_AllFields(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Companies",
 			autotasktest.EntityInfoResponse{Name: "Companies", CanCreate: true, CanQuery: true},
@@ -120,25 +118,30 @@ func TestGetFieldInfoHandler_AllFields(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := getFieldInfoHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetFieldInfoInput{EntityType: "Companies"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_field_info",
+		Arguments: map[string]any{
+			"entityType": "Companies",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
+
+	fields := parseStructuredContent[[]metadata.FieldInfo](t, result)
+	if len(fields) != 2 {
+		t.Errorf("expected 2 fields, got %d", len(fields))
+	}
 }
 
-// TestGetFieldInfoHandler_SpecificField tests filtering to a specific field.
+// TestGetFieldInfoHandler_SpecificField tests filtering to a specific field over wire.
 func TestGetFieldInfoHandler_SpecificField(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Companies",
 			autotasktest.EntityInfoResponse{Name: "Companies", CanCreate: true, CanQuery: true},
@@ -148,25 +151,31 @@ func TestGetFieldInfoHandler_SpecificField(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := getFieldInfoHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetFieldInfoInput{EntityType: "Companies", FieldName: "companyName"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_field_info",
+		Arguments: map[string]any{
+			"entityType": "Companies",
+			"fieldName":  "companyName",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
+
+	field := parseStructuredContent[metadata.FieldInfo](t, result)
+	if field.Name != "companyName" {
+		t.Errorf("expected fieldName='companyName', got %q", field.Name)
+	}
 }
 
-// TestGetFieldInfoHandler_NotFoundField tests that a non-existent field returns a text result.
+// TestGetFieldInfoHandler_NotFoundField tests that a non-existent field returns an error over wire.
 func TestGetFieldInfoHandler_NotFoundField(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
+	cs, _ := setupWireTest(t,
 		autotasktest.WithEntityMetadata(
 			"Companies",
 			autotasktest.EntityInfoResponse{Name: "Companies"},
@@ -176,18 +185,20 @@ func TestGetFieldInfoHandler_NotFoundField(t *testing.T) {
 			nil,
 		),
 	)
-	picklist := newTestPicklist(client)
-	handler := getFieldInfoHandler(picklist)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetFieldInfoInput{EntityType: "Companies", FieldName: "nonexistentField"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_field_info",
+		Arguments: map[string]any{
+			"entityType": "Companies",
+			"fieldName":  "nonexistentField",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Error("expected no error for not-found field (returns text message)")
+	if !result.IsError {
+		t.Error("expected IsError=true for non-existent field")
 	}
 }
+

--- a/tools/projects.go
+++ b/tools/projects.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -45,8 +44,8 @@ func RegisterProjectTools(s *mcp.Server, client *autotask.Client, mapper *servic
 }
 
 // searchProjectsHandler returns a handler that searches projects using the provided filters.
-func searchProjectsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectsInput) (*mcp.CallToolResult, any, error) {
+func searchProjectsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProjectsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -63,16 +62,16 @@ func searchProjectsHandler(client *autotask.Client, mapper *services.MappingCach
 
 		projects, err := autotask.List[entities.Project](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search projects: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(projects) == 0 {
-			return textResult("No projects found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(projects)
 		if err != nil {
-			return errorResult("failed to convert projects: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_projects", maxResults)
@@ -80,8 +79,8 @@ func searchProjectsHandler(client *autotask.Client, mapper *services.MappingCach
 }
 
 // createProjectHandler returns a handler that creates a new project.
-func createProjectHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectInput) (*mcp.CallToolResult, any, error) {
+func createProjectHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateProjectInput) (*mcp.CallToolResult, map[string]any, error) {
 		project := &entities.Project{
 			CompanyID:   autotask.Set(in.CompanyID),
 			ProjectName: autotask.Set(in.ProjectName),
@@ -94,14 +93,14 @@ func createProjectHandler(client *autotask.Client) func(ctx context.Context, req
 		if in.StartDate != "" {
 			t, err := parseDate(in.StartDate)
 			if err != nil {
-				return errorResult("invalid startDate format (expected YYYY-MM-DD or ISO format): %v", err)
+				return nil, nil, err
 			}
 			project.StartDateTime = autotask.Set(t)
 		}
 		if in.EndDate != "" {
 			t, err := parseDate(in.EndDate)
 			if err != nil {
-				return errorResult("invalid endDate format (expected YYYY-MM-DD or ISO format): %v", err)
+				return nil, nil, err
 			}
 			project.EndDateTime = autotask.Set(t)
 		}
@@ -111,19 +110,14 @@ func createProjectHandler(client *autotask.Client) func(ctx context.Context, req
 
 		created, err := autotask.Create[entities.Project](ctx, client, project)
 		if err != nil {
-			return errorResult("failed to create project: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created project: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created project: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/projects_test.go
+++ b/tools/projects_test.go
@@ -2,10 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -13,176 +14,138 @@ import (
 // two tools without panicking.
 func TestRegisterProjectTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterProjectTools(s, client, mapper)
 }
 
-// TestSearchProjectsHandler_ReturnsNoProjectsFound tests the empty-result case.
+// TestSearchProjectsHandler_ReturnsNoProjectsFound tests the empty-result case over wire.
 func TestSearchProjectsHandler_ReturnsNoProjectsFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchProjectsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchProjectsInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No projects found" {
-		t.Errorf("expected 'No projects found', got %q", text.Text)
-	}
-}
-
-// TestSearchProjectsHandler_ReturnsProjects tests that seeded projects are returned.
-func TestSearchProjectsHandler_ReturnsProjects(t *testing.T) {
-	project := autotasktest.ProjectFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(project))
-	mapper := newTestMapper(client)
-
-	handler := searchProjectsHandler(client, mapper)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchProjectsInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one project in results")
-	}
-}
-
-// TestCreateProjectHandler_Success tests that a project can be created.
-func TestCreateProjectHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.ProjectFixture()),
-	)
-
-	handler := createProjectHandler(client)
-	ctx := context.Background()
-
-	in := CreateProjectInput{
-		CompanyID:   1001,
-		ProjectName: "New Infrastructure Project",
-		Status:      1,
-		Description: "A test project",
-		StartDate:   "2024-01-15",
-		EndDate:     "2024-06-30",
-	}
-
-	result, _, err := handler(ctx, nil, in)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-}
-
-// TestCreateProjectHandler_InvalidDate tests that an invalid date returns an error result.
-func TestCreateProjectHandler_InvalidDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.ProjectFixture()),
-	)
-
-	handler := createProjectHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, CreateProjectInput{
-		CompanyID:   1001,
-		ProjectName: "Test",
-		Status:      1,
-		StartDate:   "not-a-date",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_projects",
+		Arguments: map[string]any{},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned projects, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
+	}
+}
+
+// TestSearchProjectsHandler_ReturnsProjects tests that seeded projects are returned over wire.
+func TestSearchProjectsHandler_ReturnsProjects(t *testing.T) {
+	project := autotasktest.ProjectFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(project))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_projects",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned project, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
+	}
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected project to contain 'id' field")
+	}
+}
+
+// TestCreateProjectHandler_Success tests creating a project over wire.
+func TestCreateProjectHandler_Success(t *testing.T) {
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.ProjectFixture()))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_project",
+		Arguments: map[string]any{
+			"companyID":   1001,
+			"projectName": "New Infrastructure Project",
+			"status":      1,
+			"description": "A test project",
+			"startDate":   "2024-01-15",
+			"endDate":     "2024-06-30",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["projectName"].(string)
+	if !strings.Contains(nameStr, "New Infrastructure Project") {
+		t.Errorf("expected projectName to contain 'New Infrastructure Project', got %v", m["projectName"])
+	}
+}
+
+// TestCreateProjectHandler_InvalidDate tests that an invalid date returns an error result over wire.
+func TestCreateProjectHandler_InvalidDate(t *testing.T) {
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.ProjectFixture()))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_project",
+		Arguments: map[string]any{
+			"companyID":   1001,
+			"projectName": "Test",
+			"status":      1,
+			"startDate":   "not-a-date",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestSearchProjectsHandler_WithFilters verifies that multiple filters can be applied.
+// TestSearchProjectsHandler_WithFilters verifies filters execution over wire.
 func TestSearchProjectsHandler_WithFilters(t *testing.T) {
 	project := autotasktest.ProjectFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(project))
-	mapper := newTestMapper(client)
-
-	handler := searchProjectsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(project))
 	ctx := context.Background()
 
-	in := SearchProjectsInput{
-		SearchTerm: "Infrastructure",
-		CompanyID:  1001,
-		Status:     1,
-		MaxResults: 10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_projects",
+		Arguments: map[string]any{
+			"searchTerm": "Infrastructure",
+			"companyID":  1001,
+			"status":     1,
+			"maxResults": 10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+

--- a/tools/register.go
+++ b/tools/register.go
@@ -88,25 +88,52 @@ func entitiesToMaps[T any](entities []*T) ([]map[string]any, error) {
 	return maps, nil
 }
 
-// textResult builds a simple text CallToolResult.
-func textResult(format string, args ...any) (*mcp.CallToolResult, any, error) {
-	text := fmt.Sprintf(format, args...)
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: text}},
-	}, nil, nil
+// ConnectionStatusOut is the structured output for autotask_test_connection.
+type ConnectionStatusOut struct {
+	Success   bool   `json:"success" jsonschema:"Whether the connection test succeeded"`
+	Entity    string `json:"entity" jsonschema:"Target entity used for verification"`
+	CanCreate bool   `json:"canCreate" jsonschema:"Permission flag for creating records"`
+	CanUpdate bool   `json:"canUpdate" jsonschema:"Permission flag for updating records"`
+	CanQuery  bool   `json:"canQuery" jsonschema:"Permission flag for querying records"`
+	Message   string `json:"message" jsonschema:"Human-readable connection status message"`
 }
 
-// errorResult builds an error CallToolResult with IsError: true.
-func errorResult(format string, args ...any) (*mcp.CallToolResult, any, error) {
-	text := fmt.Sprintf(format, args...)
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: text}},
-		IsError: true,
-	}, nil, nil
+// DeleteResultOut is the structured output for delete operations.
+type DeleteResultOut struct {
+	Success bool   `json:"success" jsonschema:"Whether the deletion succeeded"`
+	ID      int64  `json:"id" jsonschema:"ID of deleted entity"`
+	Message string `json:"message" jsonschema:"Status message"`
+}
+
+// CategorySummary describes a tool category in list_categories output.
+type CategorySummary struct {
+	Description string   `json:"description" jsonschema:"Summary of tool category purpose"`
+	ToolCount   int      `json:"toolCount" jsonschema:"Number of tools in this category"`
+	Tools       []string `json:"tools" jsonschema:"Names of tools in this category"`
+}
+
+// ToolSummary describes a tool in list_category_tools output.
+type ToolSummary struct {
+	Name        string `json:"name" jsonschema:"Tool identifier"`
+	Description string `json:"description" jsonschema:"Human-readable tool description"`
+}
+
+// CategoryToolsOut is the structured output for autotask_list_category_tools.
+type CategoryToolsOut struct {
+	Category    string        `json:"category" jsonschema:"Category identifier"`
+	Description string        `json:"description" jsonschema:"Category purpose description"`
+	Tools       []ToolSummary `json:"tools" jsonschema:"List of tools in category"`
+}
+
+// RouterOut is the structured output for autotask_router.
+type RouterOut struct {
+	Intent        string `json:"intent" jsonschema:"Original input intent query"`
+	SuggestedTool string `json:"suggestedTool" jsonschema:"Best matching tool name"`
+	Description   string `json:"description" jsonschema:"Guidance or tool description"`
 }
 
 // searchResult builds a compact formatted search result with enhancement.
-func searchResult(ctx context.Context, mapper *services.MappingCache, items []map[string]any, toolName string, maxResults int) (*mcp.CallToolResult, any, error) {
+func searchResult(ctx context.Context, mapper *services.MappingCache, items []map[string]any, toolName string, maxResults int) (*mcp.CallToolResult, services.CompactResponse, error) {
 	if mapper != nil {
 		mapper.EnhanceItems(ctx, items)
 	}
@@ -115,14 +142,18 @@ func searchResult(ctx context.Context, mapper *services.MappingCache, items []ma
 	opts := services.FormatOptions{MaxResults: maxResults}
 	compact := services.FormatCompactResponse(items, entityType, opts)
 
-	data, err := json.Marshal(compact)
-	if err != nil {
-		return errorResult("failed to marshal response: %v", err)
-	}
+	return nil, compact, nil
+}
 
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{&mcp.TextContent{Text: string(data)}},
-	}, nil, nil
+// emptySearchResult returns a zero-item compact response for searches matching no records.
+func emptySearchResult() (*mcp.CallToolResult, services.CompactResponse, error) {
+	return nil, services.CompactResponse{
+		Summary: services.CompactSummary{
+			Returned: 0,
+			HasMore:  false,
+		},
+		Items: []map[string]any{},
+	}, nil
 }
 
 // defaultMaxResults returns the effective max results limit clamped to [1, maxVal].

--- a/tools/register_test.go
+++ b/tools/register_test.go
@@ -2,11 +2,8 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 	"testing"
-
-	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestDefaultMaxResults_Default(t *testing.T) {
@@ -135,76 +132,45 @@ func TestEntitiesToMaps_Empty(t *testing.T) {
 	}
 }
 
-func TestTextResult(t *testing.T) {
-	result, out, err := textResult("Hello %s", "world")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != nil {
-		t.Errorf("expected nil out, got %v", out)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Error("expected IsError=false")
-	}
-	if len(result.Content) != 1 {
-		t.Fatalf("expected 1 content item, got %d", len(result.Content))
-	}
-}
-
-func TestErrorResult(t *testing.T) {
-	result, out, err := errorResult("something went wrong: %d", 42)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if out != nil {
-		t.Errorf("expected nil out, got %v", out)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if !result.IsError {
-		t.Error("expected IsError=true")
-	}
-	if len(result.Content) != 1 {
-		t.Fatalf("expected 1 content item, got %d", len(result.Content))
-	}
-}
-
 func TestSearchResult(t *testing.T) {
 	items := []map[string]any{
 		{"id": float64(101), "companyName": "Acme Corp", "phone": "555-1234"},
 		{"id": float64(102), "companyName": "Beta Inc", "phone": "555-5678"},
 	}
 
-	result, _, err := searchResult(context.Background(), nil, items, "autotask_search_companies", 25)
+	result, compact, err := searchResult(context.Background(), nil, items, "autotask_search_companies", 25)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result == nil || result.IsError {
-		t.Fatalf("expected valid non-error result: %v", result)
+	if result != nil {
+		t.Errorf("expected nil *CallToolResult so SDK generates it, got %v", result)
 	}
+	if compact.Summary.Returned != 2 {
+		t.Errorf("expected returned=2, got %d", compact.Summary.Returned)
+	}
+	if compact.Summary.HasMore {
+		t.Errorf("expected hasMore=false, got %v", compact.Summary.HasMore)
+	}
+	if len(compact.Items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(compact.Items))
+	}
+}
 
-	textContent, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatal("expected TextContent")
+func TestEmptySearchResult(t *testing.T) {
+	result, compact, err := emptySearchResult()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(textContent.Text), &resp); err != nil {
-		t.Fatalf("unmarshal error: %v", err)
+	if result != nil {
+		t.Errorf("expected nil *CallToolResult, got %v", result)
 	}
-
-	summary, ok := resp["summary"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected summary object: %v", resp)
+	if compact.Summary.Returned != 0 {
+		t.Errorf("expected returned=0, got %d", compact.Summary.Returned)
 	}
-	if summary["returned"] != float64(2) {
-		t.Errorf("expected returned=2, got %v", summary["returned"])
+	if compact.Summary.HasMore {
+		t.Errorf("expected hasMore=false, got %v", compact.Summary.HasMore)
 	}
-	if summary["hasMore"] != false {
-		t.Errorf("expected hasMore=false, got %v", summary["hasMore"])
+	if len(compact.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(compact.Items))
 	}
 }

--- a/tools/resources.go
+++ b/tools/resources.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/entities"
 )
@@ -26,8 +27,8 @@ func RegisterResourceTools(s *mcp.Server, client *autotask.Client) {
 }
 
 // searchResourcesHandler returns a handler that searches resources using the provided filters.
-func searchResourcesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchResourcesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchResourcesInput) (*mcp.CallToolResult, any, error) {
+func searchResourcesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchResourcesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchResourcesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -48,16 +49,16 @@ func searchResourcesHandler(client *autotask.Client) func(ctx context.Context, r
 
 		resources, err := autotask.List[entities.Resource](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search resources: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(resources) == 0 {
-			return textResult("No resources found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(resources)
 		if err != nil {
-			return errorResult("failed to convert resources: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, nil, maps, "autotask_search_resources", maxResults)

--- a/tools/resources_test.go
+++ b/tools/resources_test.go
@@ -2,10 +2,10 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -15,99 +15,84 @@ func TestRegisterResourceTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterResourceTools(s, client)
 }
 
-// TestSearchResourcesHandler_ReturnsNoResourcesFound tests the empty-result case.
+// TestSearchResourcesHandler_ReturnsNoResourcesFound tests the empty-result case over wire.
 func TestSearchResourcesHandler_ReturnsNoResourcesFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-
-	handler := searchResourcesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchResourcesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_resources",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No resources found" {
-		t.Errorf("expected 'No resources found', got %q", text.Text)
-	}
-}
-
-// TestSearchResourcesHandler_ReturnsResources tests that seeded resources are returned.
-func TestSearchResourcesHandler_ReturnsResources(t *testing.T) {
-	resource := autotasktest.ResourceFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(resource))
-
-	handler := searchResourcesHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchResourcesInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned resources, got %d", resp.Summary.Returned)
 	}
-
-	// Result should be a compact JSON response with summary + items.
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-	items, ok := resp["items"].([]any)
-	if !ok || len(items) == 0 {
-		t.Error("expected at least one resource in results")
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
 	}
 }
 
-// TestSearchResourcesHandler_WithFilters verifies that filters can be applied.
+// TestSearchResourcesHandler_ReturnsResources tests that seeded resources are returned over wire.
+func TestSearchResourcesHandler_ReturnsResources(t *testing.T) {
+	resource := autotasktest.ResourceFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(resource))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_resources",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned resource, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
+	}
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected resource to contain 'id' field")
+	}
+}
+
+// TestSearchResourcesHandler_WithFilters verifies that filters can be applied over wire.
 func TestSearchResourcesHandler_WithFilters(t *testing.T) {
 	resource := autotasktest.ResourceFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(resource))
-
-	handler := searchResourcesHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(resource))
 	ctx := context.Background()
 
 	active := true
-	in := SearchResourcesInput{
-		SearchTerm:   "John",
-		IsActive:     &active,
-		ResourceType: "Employee",
-		MaxResults:   10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_resources",
+		Arguments: map[string]any{
+			"searchTerm":   "John",
+			"isActive":     active,
+			"resourceType": "Employee",
+			"maxResults":   10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+

--- a/tools/sales.go
+++ b/tools/sales.go
@@ -2,9 +2,9 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/entities"
 )
@@ -85,30 +85,25 @@ func RegisterSalesTools(s *mcp.Server, client *autotask.Client) {
 }
 
 // getProductHandler returns a handler that retrieves a single product.
-func getProductHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetProductInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetProductInput) (*mcp.CallToolResult, any, error) {
+func getProductHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetProductInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetProductInput) (*mcp.CallToolResult, map[string]any, error) {
 		product, err := autotask.Get[entities.Product](ctx, client, in.ProductID)
 		if err != nil {
-			return errorResult("failed to get product %d: %v", in.ProductID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(product)
 		if err != nil {
-			return errorResult("failed to convert product: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal product: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchProductsHandler returns a handler that searches products.
-func searchProductsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProductsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProductsInput) (*mcp.CallToolResult, any, error) {
+func searchProductsHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchProductsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchProductsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -121,52 +116,42 @@ func searchProductsHandler(client *autotask.Client) func(ctx context.Context, re
 
 		products, err := autotask.List[entities.Product](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search products: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(products) == 0 {
-			return textResult("No products found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(products)
 		if err != nil {
-			return errorResult("failed to convert products: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal products: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_products", maxResults)
 	}
 }
 
 // getServiceHandler returns a handler that retrieves a single service.
-func getServiceHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceInput) (*mcp.CallToolResult, any, error) {
+func getServiceHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceInput) (*mcp.CallToolResult, map[string]any, error) {
 		service, err := autotask.Get[entities.Service](ctx, client, in.ServiceID)
 		if err != nil {
-			return errorResult("failed to get service %d: %v", in.ServiceID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(service)
 		if err != nil {
-			return errorResult("failed to convert service: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal service: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchServicesHandler returns a handler that searches services.
-func searchServicesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchServicesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchServicesInput) (*mcp.CallToolResult, any, error) {
+func searchServicesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchServicesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchServicesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -177,54 +162,44 @@ func searchServicesHandler(client *autotask.Client) func(ctx context.Context, re
 			q.Where("isActive", autotask.OpEq, *in.IsActive)
 		}
 
-		services, err := autotask.List[entities.Service](ctx, client, q)
+		svcs, err := autotask.List[entities.Service](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search services: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		if len(services) == 0 {
-			return textResult("No services found")
+		if len(svcs) == 0 {
+			return emptySearchResult()
 		}
 
-		maps, err := entitiesToMaps(services)
+		maps, err := entitiesToMaps(svcs)
 		if err != nil {
-			return errorResult("failed to convert services: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal services: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_services", maxResults)
 	}
 }
 
 // getServiceBundleHandler returns a handler that retrieves a single service bundle.
-func getServiceBundleHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceBundleInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceBundleInput) (*mcp.CallToolResult, any, error) {
+func getServiceBundleHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceBundleInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetServiceBundleInput) (*mcp.CallToolResult, map[string]any, error) {
 		bundle, err := autotask.Get[entities.ServiceBundle](ctx, client, in.ServiceBundleID)
 		if err != nil {
-			return errorResult("failed to get service bundle %d: %v", in.ServiceBundleID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(bundle)
 		if err != nil {
-			return errorResult("failed to convert service bundle: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal service bundle: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchServiceBundlesHandler returns a handler that searches service bundles.
-func searchServiceBundlesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchServiceBundlesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchServiceBundlesInput) (*mcp.CallToolResult, any, error) {
+func searchServiceBundlesHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in SearchServiceBundlesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchServiceBundlesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 		q := autotask.NewQuery().Limit(maxResults)
 
@@ -237,23 +212,18 @@ func searchServiceBundlesHandler(client *autotask.Client) func(ctx context.Conte
 
 		bundles, err := autotask.List[entities.ServiceBundle](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search service bundles: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(bundles) == 0 {
-			return textResult("No service bundles found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(bundles)
 		if err != nil {
-			return errorResult("failed to convert service bundles: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
-		data, err := json.MarshalIndent(maps, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal service bundles: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return searchResult(ctx, nil, maps, "autotask_search_service_bundles", maxResults)
 	}
 }

--- a/tools/sales_test.go
+++ b/tools/sales_test.go
@@ -2,10 +2,14 @@ package tools
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
+	autotask "github.com/tphakala/go-autotask"
 	"github.com/tphakala/go-autotask/autotasktest"
+	"github.com/tphakala/go-autotask/entities"
 )
 
 // TestRegisterSalesTools_NoPanic verifies registration does not panic.
@@ -15,101 +19,191 @@ func TestRegisterSalesTools_NoPanic(t *testing.T) {
 	RegisterSalesTools(s, client)
 }
 
-// TestGetProductHandler_NotFound tests that a missing product returns an error result.
+// TestGetProductHandler_NotFound tests that a missing product returns an error result over wire.
 func TestGetProductHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getProductHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetProductInput{ProductID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_product",
+		Arguments: map[string]any{
+			"productId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing product")
 	}
 }
 
-// TestSearchProductsHandler_NoResults tests the empty-result case.
-func TestSearchProductsHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchProductsHandler(client)
+// TestGetProductHandler_Success tests retrieving a seeded product over wire.
+func TestGetProductHandler_Success(t *testing.T) {
+	prod := &entities.Product{
+		ID:          autotask.Set(int64(8001)),
+		Name:        autotask.Set("Standard Monitor"),
+		Description: autotask.Set("24-inch 1080p Monitor"),
+		IsActive:    autotask.Set(true),
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(prod))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchProductsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_product",
+		Arguments: map[string]any{
+			"productId": 8001,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	nameStr, _ := m["name"].(string)
+	if !strings.Contains(nameStr, "Standard Monitor") {
+		t.Errorf("expected name to contain 'Standard Monitor', got %v", m["name"])
 	}
 }
 
-// TestGetServiceHandler_NotFound tests that a missing service returns an error result.
-func TestGetServiceHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getServiceHandler(client)
+// TestSearchProductsHandler_NoResults tests the empty-result case over wire.
+func TestSearchProductsHandler_NoResults(t *testing.T) {
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetServiceInput{ServiceID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_products",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned products, got %d", resp.Summary.Returned)
+	}
+}
+
+// TestSearchProductsHandler_WithFilters verifies product filtering over wire.
+func TestSearchProductsHandler_WithFilters(t *testing.T) {
+	prod := &entities.Product{
+		ID:       autotask.Set(int64(8001)),
+		Name:     autotask.Set("Standard Monitor"),
+		IsActive: autotask.Set(true),
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(prod))
+	ctx := context.Background()
+
+	active := true
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_products",
+		Arguments: map[string]any{
+			"searchTerm": "Monitor",
+			"isActive":   active,
+			"maxResults": 10,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got: %v", result)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 product returned, got %d", resp.Summary.Returned)
+	}
+}
+
+// TestGetServiceHandler_NotFound tests that a missing service returns an error result over wire.
+func TestGetServiceHandler_NotFound(t *testing.T) {
+	cs, _ := setupWireTest(t)
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_service",
+		Arguments: map[string]any{
+			"serviceId": 99999,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing service")
 	}
 }
 
-// TestSearchServicesHandler_NoResults tests the empty-result case.
+// TestSearchServicesHandler_NoResults tests the empty-result case over wire.
 func TestSearchServicesHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchServicesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchServicesInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_services",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned services, got %d", resp.Summary.Returned)
 	}
 }
 
-// TestGetServiceBundleHandler_NotFound tests that a missing service bundle returns an error result.
+// TestGetServiceBundleHandler_NotFound tests that a missing service bundle returns an error result over wire.
 func TestGetServiceBundleHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := getServiceBundleHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetServiceBundleInput{ServiceBundleID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_service_bundle",
+		Arguments: map[string]any{
+			"serviceBundleId": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing service bundle")
 	}
 }
 
-// TestSearchServiceBundlesHandler_NoResults tests the empty-result case.
+// TestSearchServiceBundlesHandler_NoResults tests the empty-result case over wire.
 func TestSearchServiceBundlesHandler_NoResults(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	handler := searchServiceBundlesHandler(client)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchServiceBundlesInput{SearchTerm: "acme"})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_service_bundles",
+		Arguments: map[string]any{
+			"searchTerm": "acme",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned bundles, got %d", resp.Summary.Returned)
 	}
 }
+

--- a/tools/tasks.go
+++ b/tools/tasks.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -47,8 +46,8 @@ func RegisterTaskTools(s *mcp.Server, client *autotask.Client, mapper *services.
 }
 
 // searchTasksHandler returns a handler that searches tasks using the provided filters.
-func searchTasksHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTasksInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTasksInput) (*mcp.CallToolResult, any, error) {
+func searchTasksHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTasksInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTasksInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 100)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -68,16 +67,16 @@ func searchTasksHandler(client *autotask.Client, mapper *services.MappingCache) 
 
 		tasks, err := autotask.List[entities.Task](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search tasks: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(tasks) == 0 {
-			return textResult("No tasks found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(tasks)
 		if err != nil {
-			return errorResult("failed to convert tasks: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_tasks", maxResults)
@@ -85,8 +84,8 @@ func searchTasksHandler(client *autotask.Client, mapper *services.MappingCache) 
 }
 
 // createTaskHandler returns a handler that creates a new task.
-func createTaskHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTaskInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTaskInput) (*mcp.CallToolResult, any, error) {
+func createTaskHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTaskInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTaskInput) (*mcp.CallToolResult, map[string]any, error) {
 		task := &entities.Task{
 			ProjectID: autotask.Set(in.ProjectID),
 			Title:     autotask.Set(in.Title),
@@ -105,33 +104,28 @@ func createTaskHandler(client *autotask.Client) func(ctx context.Context, req *m
 		if in.StartDateTime != "" {
 			t, err := parseDate(in.StartDateTime)
 			if err != nil {
-				return errorResult("invalid startDateTime format (expected ISO format): %v", err)
+				return nil, nil, err
 			}
 			task.StartDateTime = autotask.Set(t)
 		}
 		if in.EndDateTime != "" {
 			t, err := parseDate(in.EndDateTime)
 			if err != nil {
-				return errorResult("invalid endDateTime format (expected ISO format): %v", err)
+				return nil, nil, err
 			}
 			task.EndDateTime = autotask.Set(t)
 		}
 
 		created, err := autotask.Create[entities.Task](ctx, client, task)
 		if err != nil {
-			return errorResult("failed to create task: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created task: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created task: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/tasks_test.go
+++ b/tools/tasks_test.go
@@ -2,10 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -13,149 +14,123 @@ import (
 // two tools without panicking.
 func TestRegisterTaskTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterTaskTools(s, client, mapper)
 }
 
-// TestSearchTasksHandler_ReturnsNoTasksFound tests the empty-result case.
+// TestSearchTasksHandler_ReturnsNoTasksFound tests the empty-result case over wire.
 func TestSearchTasksHandler_ReturnsNoTasksFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchTasksHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTasksInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_tasks",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned tasks, got %d", resp.Summary.Returned)
 	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No tasks found" {
-		t.Errorf("expected 'No tasks found', got %q", text.Text)
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
 	}
 }
 
-// TestSearchTasksHandler_ReturnsTasks tests that seeded tasks are returned.
+// TestSearchTasksHandler_ReturnsTasks tests that seeded tasks are returned over wire.
 func TestSearchTasksHandler_ReturnsTasks(t *testing.T) {
 	task := autotasktest.TaskFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(task))
-	mapper := newTestMapper(client)
-
-	handler := searchTasksHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(task))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTasksInput{Status: 1})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_tasks",
+		Arguments: map[string]any{
+			"status": 1,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned task, got %d", resp.Summary.Returned)
 	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
 	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one task in results")
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected task to contain 'id' field")
 	}
 }
 
-// TestCreateTaskHandler_Success tests that a task can be created.
+// TestCreateTaskHandler_Success tests creating a task over wire.
 func TestCreateTaskHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.TaskFixture()),
-	)
-
-	handler := createTaskHandler(client)
+	proj := autotasktest.ProjectFixture()
+	projID, ok := proj.ID.Get()
+	if !ok {
+		t.Fatal("fixture project has no ID")
+	}
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(proj))
 	ctx := context.Background()
 
-	in := CreateTaskInput{
-		ProjectID:   4001,
-		Title:       "New task",
-		Status:      1,
-		Description: "A test task",
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_task",
+		Arguments: map[string]any{
+			"projectID":   projID,
+			"title":       "New task",
+			"status":      1,
+			"description": "A test task",
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "New task") {
+		t.Errorf("expected title to contain 'New task', got %v", m["title"])
 	}
 }
 
-// TestSearchTasksHandler_WithFilters verifies that multiple filters can be applied.
+// TestSearchTasksHandler_WithFilters verifies filters execution over wire.
 func TestSearchTasksHandler_WithFilters(t *testing.T) {
 	task := autotasktest.TaskFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(task))
-	mapper := newTestMapper(client)
-
-	handler := searchTasksHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(task))
 	ctx := context.Background()
 
-	in := SearchTasksInput{
-		SearchTerm:         "firmware",
-		ProjectID:          4001,
-		Status:             1,
-		AssignedResourceID: 5001,
-		MaxResults:         10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_tasks",
+		Arguments: map[string]any{
+			"searchTerm":         "firmware",
+			"projectID":          4001,
+			"status":             1,
+			"assignedResourceID": 5001,
+			"maxResults":         10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+
+

--- a/tools/tickets.go
+++ b/tools/tickets.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -83,8 +82,8 @@ func RegisterTicketTools(s *mcp.Server, client *autotask.Client, mapper *service
 }
 
 // searchTicketsHandler returns a handler that searches tickets using the provided filters.
-func searchTicketsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketsInput) (*mcp.CallToolResult, any, error) {
+func searchTicketsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTicketsInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -120,16 +119,16 @@ func searchTicketsHandler(client *autotask.Client, mapper *services.MappingCache
 
 		tickets, err := autotask.List[entities.Ticket](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search tickets: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(tickets) == 0 {
-			return textResult("No tickets found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(tickets)
 		if err != nil {
-			return errorResult("failed to convert tickets: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_tickets", maxResults)
@@ -137,34 +136,29 @@ func searchTicketsHandler(client *autotask.Client, mapper *services.MappingCache
 }
 
 // getTicketDetailsHandler returns a handler that retrieves a single ticket by ID.
-func getTicketDetailsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketDetailsInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketDetailsInput) (*mcp.CallToolResult, any, error) {
+func getTicketDetailsHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketDetailsInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in GetTicketDetailsInput) (*mcp.CallToolResult, map[string]any, error) {
 		ticket, err := autotask.Get[entities.Ticket](ctx, client, in.TicketID)
 		if err != nil {
-			return errorResult("failed to get ticket %d: %v", in.TicketID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(ticket)
 		if err != nil {
-			return errorResult("failed to convert ticket: %v", err)
+			return nil, nil, err
 		}
 
 		if mapper != nil {
 			mapper.EnhanceItems(ctx, []map[string]any{m})
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal ticket: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // createTicketHandler returns a handler that creates a new ticket.
-func createTicketHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketInput) (*mcp.CallToolResult, any, error) {
+func createTicketHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTicketInput) (*mcp.CallToolResult, map[string]any, error) {
 		ticket := &entities.Ticket{
 			CompanyID:   autotask.Set(in.CompanyID),
 			Title:       autotask.Set(in.Title),
@@ -189,26 +183,21 @@ func createTicketHandler(client *autotask.Client) func(ctx context.Context, req 
 
 		created, err := autotask.Create[entities.Ticket](ctx, client, ticket)
 		if err != nil {
-			return errorResult("failed to create ticket: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created ticket: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created ticket: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // updateTicketHandler returns a handler that updates an existing ticket.
-func updateTicketHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateTicketInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateTicketInput) (*mcp.CallToolResult, any, error) {
+func updateTicketHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in UpdateTicketInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in UpdateTicketInput) (*mcp.CallToolResult, map[string]any, error) {
 		ticket := &entities.Ticket{
 			ID: autotask.Set(in.TicketID),
 		}
@@ -234,7 +223,7 @@ func updateTicketHandler(client *autotask.Client) func(ctx context.Context, req 
 		if in.DueDateTime != "" {
 			t, err := parseDate(in.DueDateTime)
 			if err != nil {
-				return errorResult("invalid dueDateTime format (expected YYYY-MM-DD or RFC3339): %v", err)
+				return nil, nil, err
 			}
 			ticket.DueDateTime = autotask.Set(t)
 		}
@@ -244,19 +233,14 @@ func updateTicketHandler(client *autotask.Client) func(ctx context.Context, req 
 
 		updated, err := autotask.Update[entities.Ticket](ctx, client, ticket)
 		if err != nil {
-			return errorResult("failed to update ticket %d: %v", in.TicketID, err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(updated)
 		if err != nil {
-			return errorResult("failed to convert updated ticket: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal updated ticket: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }

--- a/tools/tickets_test.go
+++ b/tools/tickets_test.go
@@ -2,132 +2,100 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	autotask "github.com/tphakala/go-autotask"
-	"github.com/tphakala/go-autotask/autotasktest"
 	"github.com/tphakala/autotask-mcp/services"
+	"github.com/tphakala/go-autotask/autotasktest"
 )
-
-// newTestMapper returns a MappingCache backed by the provided client.
-func newTestMapper(client *autotask.Client) *services.MappingCache {
-	return services.NewMappingCache(client)
-}
 
 // TestRegisterTicketTools_NoPanic verifies that RegisterTicketTools registers all
 // four tools without panicking.
 func TestRegisterTicketTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterTicketTools(s, client, mapper)
 }
 
-// TestSearchTicketsHandler_ReturnsNoTicketsFound tests the empty-result case.
+// TestSearchTicketsHandler_ReturnsNoTicketsFound tests the empty-result case over wire protocol.
 func TestSearchTicketsHandler_ReturnsNoTicketsFound(t *testing.T) {
-	// Server with no pre-seeded tickets; all queries return 0 items.
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchTicketsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTicketsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_tickets",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No tickets found" {
-		t.Errorf("expected 'No tickets found', got %q", text.Text)
-	}
-}
-
-// TestSearchTicketsHandler_ReturnsTickets tests that seeded tickets are returned.
-func TestSearchTicketsHandler_ReturnsTickets(t *testing.T) {
-	ticket := autotasktest.TicketFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-	mapper := newTestMapper(client)
-
-	handler := searchTicketsHandler(client, mapper)
-	ctx := context.Background()
-
-	// Search with a specific status to avoid the default "exclude status 5" filter
-	// causing ambiguity with the fixture's status value.
-	result, _, err := handler(ctx, nil, SearchTicketsInput{Status: 1})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
 		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned tickets, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
+	}
+}
+
+// TestSearchTicketsHandler_ReturnsTickets tests that seeded tickets are returned over wire.
+func TestSearchTicketsHandler_ReturnsTickets(t *testing.T) {
+	ticket := autotasktest.TicketFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ticket))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_tickets",
+		Arguments: map[string]any{
+			"status": 1,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned ticket, got %d", resp.Summary.Returned)
 	}
-
-	// The result should be a JSON compact response.
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
 	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one ticket in results")
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected ticket to contain 'id' field")
 	}
 }
 
 // TestSearchTicketsHandler_DefaultExcludesCompleted verifies that the default query
-// path (no status filter provided) does not return a protocol error.
+// path (no status filter provided) executes cleanly over wire.
 func TestSearchTicketsHandler_DefaultExcludesCompleted(t *testing.T) {
-	// Seed an open ticket (status 1). The handler adds a "status != 5" filter by default.
 	openTicket := autotasktest.TicketFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(openTicket))
-	mapper := newTestMapper(client)
-
-	handler := searchTicketsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(openTicket))
 	ctx := context.Background()
 
-	// No Status provided → handler applies OpNotEq 5 filter.
-	result, _, err := handler(ctx, nil, SearchTicketsInput{})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_tickets",
+		Arguments: map[string]any{},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	// The fixture ticket has status=1, so it should pass the != 5 filter.
-	// However, the mock server does not implement filter evaluation server-side,
-	// so the ticket will still be returned. We just verify no protocol error occurred.
 }
 
-// TestGetTicketDetailsHandler_Success tests that a ticket is retrieved and returned.
+// TestGetTicketDetailsHandler_Success tests that a ticket is retrieved and returned with structured map over wire.
 func TestGetTicketDetailsHandler_Success(t *testing.T) {
 	ticket := autotasktest.TicketFixture()
 	ticketID, ok := ticket.ID.Get()
@@ -135,109 +103,80 @@ func TestGetTicketDetailsHandler_Success(t *testing.T) {
 		t.Fatal("fixture ticket has no ID")
 	}
 
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-	mapper := newTestMapper(client)
-
-	handler := getTicketDetailsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ticket))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketDetailsInput{TicketID: ticketID})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_details",
+		Arguments: map[string]any{
+			"ticketID": ticketID,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-
-	// Verify the ID matches.
+	m := parseStructuredContent[map[string]any](t, result)
 	idVal, ok := m["id"]
 	if !ok {
-		t.Error("expected 'id' field in result")
-	} else if int64(idVal.(float64)) != ticketID {
+		t.Error("expected 'id' field in structured result")
+	} else if fVal, isFloat := idVal.(float64); !isFloat || int64(fVal) != ticketID {
 		t.Errorf("expected id=%d, got %v", ticketID, idVal)
 	}
 }
 
-// TestGetTicketDetailsHandler_NotFound tests that a missing ticket returns an error result.
+// TestGetTicketDetailsHandler_NotFound tests that a missing ticket returns an error result over wire.
 func TestGetTicketDetailsHandler_NotFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := getTicketDetailsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, GetTicketDetailsInput{TicketID: 99999})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_get_ticket_details",
+		Arguments: map[string]any{
+			"ticketID": 99999,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for missing ticket")
 	}
 }
 
-// TestCreateTicketHandler_Success tests that a ticket can be created.
+// TestCreateTicketHandler_Success tests creating a ticket over wire protocol.
 func TestCreateTicketHandler_Success(t *testing.T) {
-	// Seed the entity store so the server accepts Tickets POSTs.
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.TicketFixture()), // initialises the store
-	)
-
-	handler := createTicketHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.TicketFixture()))
 	ctx := context.Background()
 
-	in := CreateTicketInput{
-		CompanyID:   1001,
-		Title:       "Test ticket",
-		Description: "This is a test ticket created by the handler.",
-		Priority:    2,
-		Status:      1,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_ticket",
+		Arguments: map[string]any{
+			"companyID":   1001,
+			"title":       "Test ticket",
+			"description": "This is a test ticket created by the handler.",
+			"priority":    2,
+			"status":      1,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "Test ticket") {
+		t.Errorf("expected title to contain 'Test ticket', got %v", m["title"])
 	}
 }
 
-// TestUpdateTicketHandler_Success tests that an existing ticket can be updated.
+// TestUpdateTicketHandler_Success tests updating a ticket over wire protocol.
 func TestUpdateTicketHandler_Success(t *testing.T) {
 	ticket := autotasktest.TicketFixture()
 	ticketID, ok := ticket.ID.Get()
@@ -245,43 +184,32 @@ func TestUpdateTicketHandler_Success(t *testing.T) {
 		t.Fatal("fixture ticket has no ID")
 	}
 
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-
-	handler := updateTicketHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ticket))
 	ctx := context.Background()
 
-	in := UpdateTicketInput{
-		TicketID: ticketID,
-		Title:    "Updated title",
-		Status:   2,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_update_ticket",
+		Arguments: map[string]any{
+			"ticketId": ticketID,
+			"title":    "Updated title",
+			"status":   2,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire error: %v", err)
 	}
 	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
 	}
 
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
+	m := parseStructuredContent[map[string]any](t, result)
+	titleStr, _ := m["title"].(string)
+	if !strings.Contains(titleStr, "Updated title") {
+		t.Errorf("expected title to contain 'Updated title', got %v", m["title"])
 	}
 }
 
-// TestUpdateTicketHandler_InvalidDueDateTime tests that an invalid date returns an error result.
+// TestUpdateTicketHandler_InvalidDueDateTime tests that an invalid date returns an error result over wire.
 func TestUpdateTicketHandler_InvalidDueDateTime(t *testing.T) {
 	ticket := autotasktest.TicketFixture()
 	ticketID, ok := ticket.ID.Get()
@@ -289,69 +217,63 @@ func TestUpdateTicketHandler_InvalidDueDateTime(t *testing.T) {
 		t.Fatal("fixture ticket has no ID")
 	}
 
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-
-	handler := updateTicketHandler(client)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ticket))
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, UpdateTicketInput{
-		TicketID:    ticketID,
-		DueDateTime: "not-a-date",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_update_ticket",
+		Arguments: map[string]any{
+			"ticketId":    ticketID,
+			"dueDateTime": "not-a-date",
+		},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestSearchTicketsHandler_WithFilters verifies that multiple filters can be applied
-// without panicking and that the handler returns a result.
+// TestSearchTicketsHandler_WithFilters verifies filter execution over wire.
 func TestSearchTicketsHandler_WithFilters(t *testing.T) {
 	ticket := autotasktest.TicketFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(ticket))
-	mapper := newTestMapper(client)
-
-	handler := searchTicketsHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(ticket))
 	ctx := context.Background()
 
-	// Apply several filters; the exact result count depends on the mock server's
-	// filtering, but the handler must not return a protocol error.
-	in := SearchTicketsInput{
-		CompanyID:    1001,
-		Status:       1,
-		CreatedAfter: "2024-01-01T00:00:00Z",
-		MaxResults:   10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_tickets",
+		Arguments: map[string]any{
+			"companyID":    1001,
+			"status":       1,
+			"createdAfter": "2024-01-01T00:00:00Z",
+			"maxResults":   10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	// Should not be a protocol-level error.
-	_ = result
 }
 
-// TestSearchTicketsHandler_UnassignedFilter verifies that the Unassigned flag is accepted.
+// TestSearchTicketsHandler_UnassignedFilter verifies unassigned flag over wire.
 func TestSearchTicketsHandler_UnassignedFilter(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchTicketsHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTicketsInput{Unassigned: true})
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_tickets",
+		Arguments: map[string]any{
+			"unassigned": true,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
 }
+

--- a/tools/time_entries.go
+++ b/tools/time_entries.go
@@ -2,7 +2,6 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/tphakala/autotask-mcp/services"
@@ -48,11 +47,11 @@ func RegisterTimeEntryTools(s *mcp.Server, client *autotask.Client, mapper *serv
 }
 
 // createTimeEntryHandler returns a handler that creates a new time entry.
-func createTimeEntryHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTimeEntryInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTimeEntryInput) (*mcp.CallToolResult, any, error) {
+func createTimeEntryHandler(client *autotask.Client) func(ctx context.Context, req *mcp.CallToolRequest, in CreateTimeEntryInput) (*mcp.CallToolResult, map[string]any, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in CreateTimeEntryInput) (*mcp.CallToolResult, map[string]any, error) {
 		dateWorked, err := parseDate(in.DateWorked)
 		if err != nil {
-			return errorResult("invalid dateWorked format (expected YYYY-MM-DD or ISO format): %v", err)
+			return nil, nil, err
 		}
 
 		entry := &entities.TimeEntry{
@@ -74,40 +73,35 @@ func createTimeEntryHandler(client *autotask.Client) func(ctx context.Context, r
 		if in.StartDateTime != "" {
 			t, err := parseDate(in.StartDateTime)
 			if err != nil {
-				return errorResult("invalid startDateTime format (expected ISO 8601 / RFC3339): %v", err)
+				return nil, nil, err
 			}
 			entry.StartDateTime = autotask.Set(t)
 		}
 		if in.EndDateTime != "" {
 			t, err := parseDate(in.EndDateTime)
 			if err != nil {
-				return errorResult("invalid endDateTime format (expected ISO 8601 / RFC3339): %v", err)
+				return nil, nil, err
 			}
 			entry.EndDateTime = autotask.Set(t)
 		}
 
 		created, err := autotask.Create[entities.TimeEntry](ctx, client, entry)
 		if err != nil {
-			return errorResult("failed to create time entry: %v", err)
+			return nil, nil, err
 		}
 
 		m, err := entityToMap(created)
 		if err != nil {
-			return errorResult("failed to convert created time entry: %v", err)
+			return nil, nil, err
 		}
 
-		data, err := json.MarshalIndent(m, "", "  ")
-		if err != nil {
-			return errorResult("failed to marshal created time entry: %v", err)
-		}
-
-		return textResult("%s", string(data))
+		return nil, m, nil
 	}
 }
 
 // searchTimeEntriesHandler returns a handler that searches time entries using the provided filters.
-func searchTimeEntriesHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTimeEntriesInput) (*mcp.CallToolResult, any, error) {
-	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTimeEntriesInput) (*mcp.CallToolResult, any, error) {
+func searchTimeEntriesHandler(client *autotask.Client, mapper *services.MappingCache) func(ctx context.Context, req *mcp.CallToolRequest, in SearchTimeEntriesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
+	return func(ctx context.Context, req *mcp.CallToolRequest, in SearchTimeEntriesInput) (*mcp.CallToolResult, services.CompactResponse, error) {
 		maxResults := defaultMaxResults(in.MaxResults, 25, 500)
 
 		q := autotask.NewQuery().Limit(maxResults)
@@ -127,16 +121,16 @@ func searchTimeEntriesHandler(client *autotask.Client, mapper *services.MappingC
 
 		entries, err := autotask.List[entities.TimeEntry](ctx, client, q)
 		if err != nil {
-			return errorResult("failed to search time entries: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		if len(entries) == 0 {
-			return textResult("No time entries found")
+			return emptySearchResult()
 		}
 
 		maps, err := entitiesToMaps(entries)
 		if err != nil {
-			return errorResult("failed to convert time entries: %v", err)
+			return nil, services.CompactResponse{}, err
 		}
 
 		return searchResult(ctx, mapper, maps, "autotask_search_time_entries", maxResults)

--- a/tools/time_entries_test.go
+++ b/tools/time_entries_test.go
@@ -2,10 +2,11 @@ package tools
 
 import (
 	"context"
-	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
 	"github.com/tphakala/go-autotask/autotasktest"
 )
 
@@ -13,175 +14,137 @@ import (
 // two tools without panicking.
 func TestRegisterTimeEntryTools_NoPanic(t *testing.T) {
 	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
+	mapper := services.NewMappingCache(client)
 	s := mcp.NewServer(&mcp.Implementation{Name: "test", Version: "0"}, nil)
 
-	// Should not panic.
 	RegisterTimeEntryTools(s, client, mapper)
 }
 
-// TestSearchTimeEntriesHandler_ReturnsNoEntriesFound tests the empty-result case.
+// TestSearchTimeEntriesHandler_ReturnsNoEntriesFound tests the empty-result case over wire.
 func TestSearchTimeEntriesHandler_ReturnsNoEntriesFound(t *testing.T) {
-	_, client := autotasktest.NewServer(t)
-	mapper := newTestMapper(client)
-
-	handler := searchTimeEntriesHandler(client, mapper)
+	cs, _ := setupWireTest(t)
 	ctx := context.Background()
 
-	result, _, err := handler(ctx, nil, SearchTimeEntriesInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true")
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-	if text.Text != "No time entries found" {
-		t.Errorf("expected 'No time entries found', got %q", text.Text)
-	}
-}
-
-// TestSearchTimeEntriesHandler_ReturnsEntries tests that seeded entries are returned.
-func TestSearchTimeEntriesHandler_ReturnsEntries(t *testing.T) {
-	entry := autotasktest.TimeEntryFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(entry))
-	mapper := newTestMapper(client)
-
-	handler := searchTimeEntriesHandler(client, mapper)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, SearchTimeEntriesInput{})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var resp map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &resp); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-
-	items, ok := resp["items"].([]any)
-	if !ok {
-		t.Fatalf("expected 'items' array in response, got: %v", resp)
-	}
-	if len(items) == 0 {
-		t.Error("expected at least one time entry in results")
-	}
-}
-
-// TestCreateTimeEntryHandler_Success tests that a time entry can be created.
-func TestCreateTimeEntryHandler_Success(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.TimeEntryFixture()),
-	)
-
-	handler := createTimeEntryHandler(client)
-	ctx := context.Background()
-
-	in := CreateTimeEntryInput{
-		ResourceID:   5001,
-		DateWorked:   "2024-01-15",
-		HoursWorked:  2.5,
-		SummaryNotes: "Fixed server issue",
-		TicketID:     3001,
-	}
-
-	result, _, err := handler(ctx, nil, in)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if result.IsError {
-		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
-	}
-	if len(result.Content) == 0 {
-		t.Fatal("expected content in result")
-	}
-
-	text, ok := result.Content[0].(*mcp.TextContent)
-	if !ok {
-		t.Fatalf("expected TextContent, got %T", result.Content[0])
-	}
-
-	var m map[string]any
-	if err := json.Unmarshal([]byte(text.Text), &m); err != nil {
-		t.Fatalf("result is not valid JSON: %v\ncontent: %s", err, text.Text)
-	}
-}
-
-// TestCreateTimeEntryHandler_InvalidDate tests that an invalid date returns an error result.
-func TestCreateTimeEntryHandler_InvalidDate(t *testing.T) {
-	_, client := autotasktest.NewServer(t,
-		autotasktest.WithEntity(autotasktest.TimeEntryFixture()),
-	)
-
-	handler := createTimeEntryHandler(client)
-	ctx := context.Background()
-
-	result, _, err := handler(ctx, nil, CreateTimeEntryInput{
-		ResourceID:   5001,
-		DateWorked:   "not-a-date",
-		HoursWorked:  1.0,
-		SummaryNotes: "test",
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_time_entries",
+		Arguments: map[string]any{},
 	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned != 0 {
+		t.Errorf("expected 0 returned entries, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) != 0 {
+		t.Errorf("expected 0 items, got %d", len(resp.Items))
+	}
+}
+
+// TestSearchTimeEntriesHandler_ReturnsEntries tests that seeded entries are returned over wire.
+func TestSearchTimeEntriesHandler_ReturnsEntries(t *testing.T) {
+	entry := autotasktest.TimeEntryFixture()
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(entry))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "autotask_search_time_entries",
+		Arguments: map[string]any{},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
+	}
+
+	resp := parseStructuredContent[services.CompactResponse](t, result)
+	if resp.Summary.Returned < 1 {
+		t.Errorf("expected at least 1 returned time entry, got %d", resp.Summary.Returned)
+	}
+	if len(resp.Items) == 0 {
+		t.Fatal("expected items in response")
+	}
+	if resp.Items[0]["id"] == nil {
+		t.Error("expected time entry to contain 'id' field")
+	}
+}
+
+// TestCreateTimeEntryHandler_Success tests creating a time entry over wire.
+func TestCreateTimeEntryHandler_Success(t *testing.T) {
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.TimeEntryFixture()))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_time_entry",
+		Arguments: map[string]any{
+			"resourceID":   5001,
+			"dateWorked":   "2024-01-15",
+			"hoursWorked":  2.5,
+			"summaryNotes": "Fixed server issue",
+			"ticketID":     3001,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire error: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("expected non-error result, got IsError=true; content: %v", result.Content)
+	}
+
+	m := parseStructuredContent[map[string]any](t, result)
+	notesStr, _ := m["summaryNotes"].(string)
+	if !strings.Contains(notesStr, "Fixed server issue") {
+		t.Errorf("expected summaryNotes to contain 'Fixed server issue', got %v", m["summaryNotes"])
+	}
+}
+
+// TestCreateTimeEntryHandler_InvalidDate tests that an invalid date returns an error result over wire.
+func TestCreateTimeEntryHandler_InvalidDate(t *testing.T) {
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(autotasktest.TimeEntryFixture()))
+	ctx := context.Background()
+
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_create_time_entry",
+		Arguments: map[string]any{
+			"resourceID":   5001,
+			"dateWorked":   "not-a-date",
+			"hoursWorked":  1.0,
+			"summaryNotes": "test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected wire protocol error: %v", err)
 	}
 	if !result.IsError {
 		t.Error("expected IsError=true for invalid date")
 	}
 }
 
-// TestSearchTimeEntriesHandler_WithFilters verifies that filters can be applied.
+// TestSearchTimeEntriesHandler_WithFilters verifies filters execution over wire.
 func TestSearchTimeEntriesHandler_WithFilters(t *testing.T) {
 	entry := autotasktest.TimeEntryFixture()
-	_, client := autotasktest.NewServer(t, autotasktest.WithEntity(entry))
-	mapper := newTestMapper(client)
-
-	handler := searchTimeEntriesHandler(client, mapper)
+	cs, _ := setupWireTest(t, autotasktest.WithEntity(entry))
 	ctx := context.Background()
 
-	in := SearchTimeEntriesInput{
-		ResourceID:      5001,
-		TicketID:        3001,
-		DateWorkedAfter: "2024-01-01T00:00:00Z",
-		MaxResults:      10,
-	}
-
-	result, _, err := handler(ctx, nil, in)
+	result, err := cs.CallTool(ctx, &mcp.CallToolParams{
+		Name: "autotask_search_time_entries",
+		Arguments: map[string]any{
+			"resourceID":      5001,
+			"ticketID":        3001,
+			"dateWorkedAfter": "2024-01-01T00:00:00Z",
+			"maxResults":      10,
+		},
+	})
 	if err != nil {
-		t.Fatalf("unexpected protocol error: %v", err)
+		t.Fatalf("unexpected wire error: %v", err)
 	}
-	if result == nil {
-		t.Fatal("expected non-nil result")
+	if result.IsError {
+		t.Errorf("expected no error result, got IsError=true; content: %v", result.Content)
 	}
-	_ = result
 }
+

--- a/tools/wire_test.go
+++ b/tools/wire_test.go
@@ -1,0 +1,92 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/tphakala/autotask-mcp/services"
+	autotask "github.com/tphakala/go-autotask"
+	"github.com/tphakala/go-autotask/autotasktest"
+)
+
+// setupWireTest sets up a full in-memory MCP server with all tools registered and connected to an MCP client.
+func setupWireTest(t *testing.T, opts ...autotasktest.ServerOption) (*mcp.ClientSession, *autotask.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, client := autotasktest.NewServer(t, opts...)
+	mapper := services.NewMappingCache(client)
+	picklist := services.NewPicklistCache(client)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "autotask-mcp-test", Version: "v0.0.1"}, nil)
+	RegisterAll(server, client, mapper, picklist)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	return clientSession, client
+}
+
+// setupLazyWireTest sets up a lazy-loading in-memory MCP server with meta-tools registered.
+func setupLazyWireTest(t *testing.T, opts ...autotasktest.ServerOption) (*mcp.ClientSession, *autotask.Client) {
+	t.Helper()
+	ctx := context.Background()
+
+	_, client := autotasktest.NewServer(t, opts...)
+	mapper := services.NewMappingCache(client)
+	picklist := services.NewPicklistCache(client)
+
+	server := mcp.NewServer(&mcp.Implementation{Name: "autotask-lazy-test", Version: "v0.0.1"}, nil)
+	RegisterLazyTools(server, client, mapper, picklist)
+
+	clientTransport, serverTransport := mcp.NewInMemoryTransports()
+
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = serverSession.Close() })
+
+	mcpClient := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "v0.0.1"}, nil)
+	clientSession, err := mcpClient.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client Connect: %v", err)
+	}
+	t.Cleanup(func() { _ = clientSession.Close() })
+
+	return clientSession, client
+}
+
+// parseStructuredContent decodes the structured content from a CallToolResult into target struct.
+func parseStructuredContent[T any](t *testing.T, result *mcp.CallToolResult) T {
+	t.Helper()
+	if result == nil {
+		t.Fatal("expected non-nil CallToolResult")
+	}
+	if result.StructuredContent == nil {
+		t.Fatalf("expected non-nil StructuredContent in result: %+v", result)
+	}
+	data, err := json.Marshal(result.StructuredContent)
+	if err != nil {
+		t.Fatalf("failed to marshal StructuredContent: %v", err)
+	}
+	var out T
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("failed to unmarshal StructuredContent into %T: %v", out, err)
+	}
+	return out
+}


### PR DESCRIPTION
## Summary
This pull request transitions the MCP server tool layer to typed `StructuredContent` output signatures matching the MCP Go SDK (`github.com/modelcontextprotocol/go-sdk` v1.7.0) across all 59 tools in all 15 domain modules and lazy dispatch meta-tools. It also expands the test suite across every module to run end-to-end wire-protocol tests over in-memory transports (`mcp.NewInMemoryTransports()`) with full `StructuredContent` assertions.

Key changes:
- Refactored all 59 MCP tool handlers across 15 domain files and lazy registry to return typed `(nil, Out, nil)` / `(nil, zero, err)` signatures, removing redundant string serialization in favor of returning `services.CompactResponse` or structured maps/structs directly.
- Standardized `jsonschema` struct tags in `services/formatter.go` and `tools/register.go` to standard bare description strings.
- Created `tools/wire_test.go` with `setupWireTest`, `setupLazyWireTest`, and `parseStructuredContent[T]` for in-memory transport wire testing with automatic session cleanup.
- Refactored all 16 test suites in `tools/*_test.go` and root `integration_test.go` to execute end-to-end wire protocol calls via `cs.CallTool` with structured content assertions.
- Added graceful `NotFoundError` handling in child entity search handlers (ticket notes, project notes, company notes, ticket attachments).

## Related Issues
Fixes #26
Fixes #34

## Test Plan
- [x] Ran full unit and integration test suite with Go race detector: `go test -v -race ./...` (100% PASS)
- [x] Ran linter: `golangci-lint run ./...` (0 issues)
- [x] Verified TDQS tool definitions quality tests pass
- [x] Verified lazy dispatcher coverage and keyword routing over wire protocol